### PR TITLE
Added a star tag so we can easily detect and handle colliding stars.

### DIFF
--- a/projects/AstroBalance/Assets/Prefabs/Star.prefab
+++ b/projects/AstroBalance/Assets/Prefabs/Star.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 2183087405533850476}
   m_Layer: 0
   m_Name: Star
-  m_TagString: Untagged
+  m_TagString: Star
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/Star.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/Star.cs
@@ -34,7 +34,6 @@ public class Star : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D other)
     {
-
         if (other.CompareTag("Star"))
         {
             // ignore collisions between stars

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/Star.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/Star.cs
@@ -34,6 +34,13 @@ public class Star : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D other)
     {
+
+        if (other.CompareTag("Star"))
+        {
+            // ignore collisions between stars
+            return;
+        }
+
         if (!gameManager.IsGameActive())
         {
             return;

--- a/projects/AstroBalance/ProjectSettings/TagManager.asset
+++ b/projects/AstroBalance/ProjectSettings/TagManager.asset
@@ -2,8 +2,9 @@
 %TAG !u! tag:unity3d.com,2011:
 --- !u!78 &1
 TagManager:
-  serializedVersion: 2
-  tags: []
+  serializedVersion: 3
+  tags:
+  - Star
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
To fix #66 we can add a "Star" tag to the star prefab, which makes it easy to detect and ignore collision between stars.