### PR TITLE
Add additional save data for star seek and space walk games

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ You may need to [download the drivers](https://www.gaming.tobii.com/getstarted/)
 
 ## Documentation
 
-Documentation for each mini-game is provided under [`docs/`](/docs/), focusing on how to edit important values during play testing.
+Documentation for each mini-game is provided under [`docs/`](/docs/) covering:
+- how to edit important values during play testing.
+- the save data each mini-game produces
 
 ## Developing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Documentation
+
+This directory contains one `.md` file per mini-game, with information about its implementation / save data.
+
+Note: all save data is saved as `.csv` files to the default location (on Windows):
+`C:\Users\username\AppData\LocalLow\DefaultCompany\AstroBalance` (you will need to replace `username` with your own)
+
+One additional save file `SessionSummary.csv` is produced providing an overview of all games. This is described in `session-summary.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,4 +5,5 @@ This directory contains one `.md` file per mini-game, with information about its
 Note: all save data is saved as `.csv` files to the default location (on Windows):
 `C:\Users\username\AppData\LocalLow\DefaultCompany\AstroBalance` (you will need to replace `username` with your own)
 
-One additional save file `SessionSummary.csv` is produced providing an overview of all games. This is described in `session-summary.md`.
+One additional save file `SessionSummary.csv` is produced providing an overview of all games. 
+This is described in [`session-summary.md`](./session-summary.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,11 @@
 
 This directory contains one `.md` file per mini-game, with information about its implementation / save data.
 
-Note: all save data is saved as `.csv` files to the default location (on Windows):
-`C:\Users\username\AppData\LocalLow\DefaultCompany\AstroBalance` (you will need to replace `username` with your own)
+Note: all save data is saved as `.csv` files to the default location:
+- on Windows: `C:\Users\username\AppData\LocalLow\DefaultCompany\AstroBalance` 
+- on Linux: `/home/username/.config/unity3d/DefaultCompany/AstroBalance`
+
+(you will need to replace `username` with your own)
 
 One additional save file `SessionSummary.csv` is produced providing an overview of all games. 
 This is described in [`session-summary.md`](./session-summary.md).

--- a/docs/session-summary.md
+++ b/docs/session-summary.md
@@ -1,0 +1,18 @@
+# Session summary
+
+An overview of every time `Astrobalance` has been played is provided in the `SessionSummary.csv` file.
+There is one row per session (which is the time from launching Unity, to quitting the application), with the 
+following values:
+
+- `sessionNumber`: a unique id per session
+- `sessionDate`: the date of the session in format YYYY-MM-DD
+- `sessionStartTime`: the session start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
+- `sessionEndTime`: the session end time in format HH:MM:ss (local time - see sessionStartTime description)
+- `totalSessionDurationMinutes`: total number of minutes in this session..
+- `game1RocketLaunchPlayed`: whether a _complete_ game of rocket launch was played in this session.
+- `game2StarCollectorPlayed`: whether a _complete_ game of star collector was played in this session.
+- `game3StarSeekPlayed`: whether a _complete_ game of star seek was played in this session.
+- `game4StarMapPlayed`: whether a _complete_ game of star map was played in this session.
+- `game5SpaceWalkPlayed`: whether a _complete_ game of space walk was played in this session.
+- `game6ZeroGravityPlayed`: whether a _complete_ game of zero gravity was played in this session.
+- `totalGamesPlayed`: total number of mini-games played. Maximum is 6 (playing the same game multiple times doesn't count)

--- a/docs/session-summary.md
+++ b/docs/session-summary.md
@@ -8,11 +8,11 @@ following values:
 - `sessionDate`: the date of the session in format YYYY-MM-DD
 - `sessionStartTime`: the session start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
 - `sessionEndTime`: the session end time in format HH:MM:ss (local time - see sessionStartTime description)
-- `totalSessionDurationMinutes`: total number of minutes in this session..
-- `game1RocketLaunchPlayed`: whether a _complete_ game of rocket launch was played in this session.
-- `game2StarCollectorPlayed`: whether a _complete_ game of star collector was played in this session.
-- `game3StarSeekPlayed`: whether a _complete_ game of star seek was played in this session.
-- `game4StarMapPlayed`: whether a _complete_ game of star map was played in this session.
-- `game5SpaceWalkPlayed`: whether a _complete_ game of space walk was played in this session.
-- `game6ZeroGravityPlayed`: whether a _complete_ game of zero gravity was played in this session.
-- `totalGamesPlayed`: total number of mini-games played. Maximum is 6 (playing the same game multiple times doesn't count)
+- `totalSessionDuration`: total duration of session in format HH:MM:ss
+- `nCompleteRocketLaunchGames`: number of complete games of rocket launch played in this session.
+- `nCompleteStarCollectorGames`: number of complete games of star collector played in this session.
+- `nCompleteStarSeekGames`: number of complete games of star seek played in this session.
+- `nCompleteStarMapGames`: number of complete games of star map played in this session.
+- `nCompleteSpaceWalkGames`: number of complete games of space walk played in this session.
+- `nCompleteZeroGravityGames`: number of complete games of zero gravity played in this session.
+- `totalCompleteGames`: total number of complete mini-games played in this session.

--- a/docs/session-summary.md
+++ b/docs/session-summary.md
@@ -5,9 +5,9 @@ There is one row per session (which is the time from launching Unity, to quittin
 following values:
 
 - `sessionNumber`: a unique id per session
-- `sessionDate`: the date of the session in format YYYY-MM-DD
-- `sessionStartTime`: the session start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
-- `sessionEndTime`: the session end time in format HH:MM:ss (local time - see sessionStartTime description)
+- `date`: the date of the session in format YYYY-MM-DD
+- `startTime`: the session start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
+- `endTime`: the session end time in format HH:MM:ss (local time - see startTime description)
 - `totalSessionDuration`: total duration of session in format HH:MM:ss
 - `nCompleteRocketLaunchGames`: number of complete games of rocket launch played in this session.
 - `nCompleteStarCollectorGames`: number of complete games of star collector played in this session.

--- a/docs/space-walking.md
+++ b/docs/space-walking.md
@@ -27,3 +27,19 @@ The space walking mini-game scores the player on completed steps (up / down / le
   - Number of seconds to delay before destroying the arrow on full fill
   - Label text for the arrow
   - Colour of arrow fill
+
+## Save data
+
+Data is saved to `SpaceWalkingScores.csv`, with one row per game session. Values are:
+
+- `sessionNumber`: a unique id per game session
+- `sessionDate`: the date of the game session in format YYYY-MM-DD
+- `sessionStartTime`: the game start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
+- `sessionEndTime`: the game end time in format HH:MM:ss (local time - see sessionStartTime description)
+- `gameCompleted`: whether this game was completed. If they exited early, this will be false.
+- `timeLimitSeconds`: the time limit set for this game in seconds
+- `gameDurationSeconds`: how long the game was played in seconds. If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.
+- `nCompleteSteps`: number of completed steps during this game. One complete step = a step out and back to the centre.
+- `headTurnsActive`: whether head turn arrows were active for this game (only active at highest difficulty level)
+- `nCompleteHeadTurns`: number of completed head turns (will be 0 if `headTurnsActive` is false)
+- `adaptiveLevel`: an integer (1 or above) representing the current difficulty level. This increases by 1 every time the time limit is increased, and when head turns are activated at the highest difficulty level.

--- a/docs/space-walking.md
+++ b/docs/space-walking.md
@@ -30,12 +30,13 @@ The space walking mini-game scores the player on completed steps (up / down / le
 
 ## Save data
 
-Data is saved to `SpaceWalkingScores.csv`, with one row per game session. Values are:
+Data is saved to `SpaceWalkingScores.csv`, with one row per played game. Values are:
 
-- `sessionNumber`: a unique id per game session
-- `sessionDate`: the date of the game session in format YYYY-MM-DD
-- `sessionStartTime`: the game start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
-- `sessionEndTime`: the game end time in format HH:MM:ss (local time - see sessionStartTime description)
+- `gameNumber`: a unique id per played space walk game
+- `sessionNumber`: the session this game was played in (corresponds to sessionNumber in [`SessionSummary.csv`](./session-summary.md))
+- `date`: the date the game was played in format YYYY-MM-DD
+- `startTime`: the game start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
+- `endTime`: the game end time in format HH:MM:ss (local time - see startTime description)
 - `gameCompleted`: whether this game was completed. If they exited early, this will be false.
 - `timeLimitSeconds`: the time limit set for this game in seconds
 - `gameDurationSeconds`: how long the game was played in seconds. If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.

--- a/docs/star-seek.md
+++ b/docs/star-seek.md
@@ -20,3 +20,17 @@ The star seek mini-game uses gaze + head position to collect stars that appear a
 - **Prefabs/StarSeekStar**: values related to 'locking on' to a star
   - Time required to collect a star (with both gaze + head pose crosshair aligned)
   - Level of bloom (glow) for a star with a single or double lock
+
+## Save data
+
+Data is saved to `StarSeekScores.csv`, with one row per game session. Values are:
+
+- `sessionNumber`: a unique id per game session
+- `sessionDate`: the date of the game session in format YYYY-MM-DD
+- `sessionStartTime`: the game start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
+- `sessionEndTime`: the game end time in format HH:MM:ss (local time - see sessionStartTime description)
+- `gameCompleted`: whether this game was completed. If they exited early, this will be false.
+- `timeLimitSeconds`: the time limit set for this game in seconds
+- `gameDurationSeconds`: how long the game was played in seconds. If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.
+- `nStarsCollected`: the number of stars collected during the game
+- `adaptiveLevel`: an integer (1 or above) representing the current difficulty level. Every time the time limit is increased, this level increases by one.

--- a/docs/star-seek.md
+++ b/docs/star-seek.md
@@ -23,12 +23,13 @@ The star seek mini-game uses gaze + head position to collect stars that appear a
 
 ## Save data
 
-Data is saved to `StarSeekScores.csv`, with one row per game session. Values are:
+Data is saved to `StarSeekScores.csv`, with one row per played game. Values are:
 
-- `sessionNumber`: a unique id per game session
-- `sessionDate`: the date of the game session in format YYYY-MM-DD
-- `sessionStartTime`: the game start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
-- `sessionEndTime`: the game end time in format HH:MM:ss (local time - see sessionStartTime description)
+- `gameNumber`: a unique id per played star seek game
+- `sessionNumber`: the session this game was played in (corresponds to sessionNumber in [`SessionSummary.csv`](./session-summary.md))
+- `date`: the date the game was played in format YYYY-MM-DD
+- `startTime`: the game start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
+- `endTime`: the game end time in format HH:MM:ss (local time - see startTime description)
 - `gameCompleted`: whether this game was completed. If they exited early, this will be false.
 - `timeLimitSeconds`: the time limit set for this game in seconds
 - `gameDurationSeconds`: how long the game was played in seconds. If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.

--- a/projects/AstroBalance/Assets/Scripts/SaveData/CaptureSessionData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/CaptureSessionData.cs
@@ -21,7 +21,7 @@ public class CaptureSessionData : MonoBehaviour
             newSession.sessionNumber = 1;
             sessionData.Save(newSession);
         }
-        else if (lastSession.endTime != "")
+        else if (lastSession.sessionEndTime != "")
         {
             // The last session has ended, so create a new one
             SessionData newSession = new SessionData();
@@ -38,12 +38,12 @@ public class CaptureSessionData : MonoBehaviour
         SaveData<SessionData> sessionData = new(saveFilename);
         SessionData lastSession = sessionData.GetLast();
 
-        if (lastSession.endTime == "")
+        if (lastSession.sessionEndTime == "")
         {
             lastSession.LogEndTime();
             TimeSpan sessionDuration = DateTime
-                .Parse(lastSession.endTime)
-                .Subtract(DateTime.Parse(lastSession.startTime));
+                .Parse(lastSession.sessionEndTime)
+                .Subtract(DateTime.Parse(lastSession.sessionStartTime));
             lastSession.totalSessionDurationMinutes = sessionDuration.Minutes;
             sessionData.Overwrite(lastSession);
         }

--- a/projects/AstroBalance/Assets/Scripts/SaveData/CaptureSessionData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/CaptureSessionData.cs
@@ -14,18 +14,12 @@ public class CaptureSessionData : MonoBehaviour
         SaveData<SessionData> sessionData = new(saveFilename);
         SessionData lastSession = sessionData.GetLast();
 
-        if (lastSession is null)
+        // If there is no summary data yet, or the last session has ended,
+        // create a new session
+        if (lastSession is null || lastSession.sessionEndTime != "")
         {
-            // There is no summary data yet
             SessionData newSession = new SessionData();
-            newSession.sessionNumber = 1;
-            sessionData.Save(newSession);
-        }
-        else if (lastSession.sessionEndTime != "")
-        {
-            // The last session has ended, so create a new one
-            SessionData newSession = new SessionData();
-            newSession.sessionNumber = lastSession.sessionNumber + 1;
+            newSession.sessionNumber = sessionData.GetNextSessionNumber();
             sessionData.Save(newSession);
         }
     }

--- a/projects/AstroBalance/Assets/Scripts/SaveData/CaptureSessionData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/CaptureSessionData.cs
@@ -66,6 +66,6 @@ public class CaptureSessionData : MonoBehaviour
     public static int CurrentSessionNumber()
     {
         SaveData<SessionData> sessionData = new(saveFilename);
-        return sessionData.GetLastSessionNumber();
+        return sessionData.GetCurrentSessionNumber();
     }
 }

--- a/projects/AstroBalance/Assets/Scripts/SaveData/CaptureSessionData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/CaptureSessionData.cs
@@ -16,7 +16,7 @@ public class CaptureSessionData : MonoBehaviour
 
         // If there is no summary data yet, or the last session has ended,
         // create a new session
-        if (lastSession is null || lastSession.sessionEndTime != "")
+        if (lastSession is null || lastSession.endTime != "")
         {
             SessionData newSession = new SessionData();
             newSession.sessionNumber = sessionData.GetNextSessionNumber();
@@ -32,12 +32,12 @@ public class CaptureSessionData : MonoBehaviour
         SaveData<SessionData> sessionData = new(saveFilename);
         SessionData lastSession = sessionData.GetLast();
 
-        if (lastSession.sessionEndTime == "")
+        if (lastSession.endTime == "")
         {
             lastSession.LogEndTime();
             TimeSpan sessionDuration = DateTime
-                .Parse(lastSession.sessionEndTime)
-                .Subtract(DateTime.Parse(lastSession.sessionStartTime));
+                .Parse(lastSession.endTime)
+                .Subtract(DateTime.Parse(lastSession.startTime));
             lastSession.totalSessionDuration = sessionDuration.ToString(@"hh\:mm\:ss");
             sessionData.Overwrite(lastSession);
         }
@@ -58,5 +58,14 @@ public class CaptureSessionData : MonoBehaviour
         nGamesField.SetValue(lastSession, nGames + 1);
         lastSession.UpdateTotalCompleteGames();
         sessionData.Overwrite(lastSession);
+    }
+
+    /// <summary>
+    /// Get number of current session (last row in session save data)
+    /// </summary>
+    public static int CurrentSessionNumber()
+    {
+        SaveData<SessionData> sessionData = new(saveFilename);
+        return sessionData.GetLastSessionNumber();
     }
 }

--- a/projects/AstroBalance/Assets/Scripts/SaveData/Data.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/Data.cs
@@ -7,18 +7,19 @@ using System;
 [System.Serializable]
 public abstract class Data
 {
-    public string date;
-    public string startTime;
-    public string endTime;
+    public int sessionNumber = 1;
+    public string sessionDate;
+    public string sessionStartTime;
+    public string sessionEndTime;
 
     public Data()
     {
-        date = DateTime.Now.ToString("yyyy-MM-dd");
-        startTime = DateTime.Now.ToString("HH:mm:ss");
+        sessionDate = DateTime.Now.ToString("yyyy-MM-dd");
+        sessionStartTime = DateTime.Now.ToString("HH:mm:ss");
     }
 
     public void LogEndTime()
     {
-        endTime = DateTime.Now.ToString("HH:mm:ss");
+        sessionEndTime = DateTime.Now.ToString("HH:mm:ss");
     }
 }

--- a/projects/AstroBalance/Assets/Scripts/SaveData/Data.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/Data.cs
@@ -7,19 +7,19 @@ using System;
 [System.Serializable]
 public abstract class Data
 {
-    public int sessionNumber = 1;
-    public string sessionDate;
-    public string sessionStartTime;
-    public string sessionEndTime;
+    public int sessionNumber;
+    public string date;
+    public string startTime;
+    public string endTime;
 
     public Data()
     {
-        sessionDate = DateTime.Now.ToString("yyyy-MM-dd");
-        sessionStartTime = DateTime.Now.ToString("HH:mm:ss");
+        date = DateTime.Now.ToString("yyyy-MM-dd");
+        startTime = DateTime.Now.ToString("HH:mm:ss");
     }
 
     public void LogEndTime()
     {
-        sessionEndTime = DateTime.Now.ToString("HH:mm:ss");
+        endTime = DateTime.Now.ToString("HH:mm:ss");
     }
 }

--- a/projects/AstroBalance/Assets/Scripts/SaveData/GameData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/GameData.cs
@@ -7,5 +7,6 @@ using System;
 [System.Serializable]
 public abstract class GameData : Data
 {
+    public int gameNumber = 1;
     public bool gameCompleted = false;
 }

--- a/projects/AstroBalance/Assets/Scripts/SaveData/SaveData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/SaveData.cs
@@ -169,7 +169,7 @@ public class SaveData<T>
 
     /// <summary>
     /// Return info on all public fields.
-    /// Order is: date, startTime, endTime, then any
+    /// Order is: sessionNumber, sessionDate, sessionStartTime, sessionEndTime, then any
     /// other fields in alphabetical order.
     /// </summary>
     private FieldInfo[] GetFields(T data)
@@ -178,16 +178,17 @@ public class SaveData<T>
         FieldInfo[] fields = type.GetFields();
         FieldInfo[] sortedFields = new FieldInfo[fields.Length];
 
-        // We return date, startTime, endTime, first (as this is general data
+        // We return session number, date, startTime, endTime first (as this is general data
         // for all save files, and useful to have at the start of the csv)
-        sortedFields[0] = type.GetField("date");
-        sortedFields[1] = type.GetField("startTime");
-        sortedFields[2] = type.GetField("endTime");
+        sortedFields[0] = type.GetField("sessionNumber");
+        sortedFields[1] = type.GetField("sessionDate");
+        sortedFields[2] = type.GetField("sessionStartTime");
+        sortedFields[3] = type.GetField("sessionEndTime");
 
         // Then, all other fields sorted in alphabetical order
         Array.Sort(fields, (x, y) => String.Compare(x.Name, y.Name));
 
-        int nextIndex = 3;
+        int nextIndex = 4;
         foreach (FieldInfo field in fields)
         {
             if (!sortedFields.Contains(field))

--- a/projects/AstroBalance/Assets/Scripts/SaveData/SaveData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/SaveData.cs
@@ -116,6 +116,25 @@ public class SaveData<T>
     }
 
     /// <summary>
+    /// Get next available session number.
+    /// </summary>
+    public int GetNextSessionNumber()
+    {
+        T lastSession = GetLast();
+        int nextNumber;
+        if (lastSession is not null)
+        {
+            nextNumber = lastSession.sessionNumber + 1;
+        }
+        else
+        {
+            nextNumber = 1;
+        }
+
+        return nextNumber;
+    }
+
+    /// <summary>
     /// Convert csv header / row into a Data object.
     /// </summary>
     /// <param name="csvHeader">Csv header as string (first line of csv file)</param>

--- a/projects/AstroBalance/Assets/Scripts/SaveData/SaveData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/SaveData.cs
@@ -116,9 +116,9 @@ public class SaveData<T>
     }
 
     /// <summary>
-    /// Get last session number.
+    /// Get current session number.
     /// </summary>
-    public int GetLastSessionNumber()
+    public int GetCurrentSessionNumber()
     {
         T lastSession = GetLast();
         return lastSession is not null ? lastSession.sessionNumber : 1;

--- a/projects/AstroBalance/Assets/Scripts/SaveData/SaveData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/SaveData.cs
@@ -121,17 +121,7 @@ public class SaveData<T>
     public int GetNextSessionNumber()
     {
         T lastSession = GetLast();
-        int nextNumber;
-        if (lastSession is not null)
-        {
-            nextNumber = lastSession.sessionNumber + 1;
-        }
-        else
-        {
-            nextNumber = 1;
-        }
-
-        return nextNumber;
+        return lastSession is not null ? lastSession.sessionNumber + 1 : 1;
     }
 
     /// <summary>

--- a/projects/AstroBalance/Assets/Scripts/SaveData/SaveData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/SaveData.cs
@@ -116,6 +116,15 @@ public class SaveData<T>
     }
 
     /// <summary>
+    /// Get last session number.
+    /// </summary>
+    public int GetLastSessionNumber()
+    {
+        T lastSession = GetLast();
+        return lastSession is not null ? lastSession.sessionNumber : 1;
+    }
+
+    /// <summary>
     /// Get next available session number.
     /// </summary>
     public int GetNextSessionNumber()
@@ -155,9 +164,9 @@ public class SaveData<T>
     private string DataToCsv(T data, bool headerOnly)
     {
         StringBuilder csvString = new StringBuilder();
-        FieldInfo[] fields = GetFields(data);
+        List<FieldInfo> fields = GetFields(data);
 
-        for (int i = 0; i < fields.Length; i++)
+        for (int i = 0; i < fields.Count(); i++)
         {
             if (headerOnly)
             {
@@ -167,7 +176,7 @@ public class SaveData<T>
             {
                 csvString.Append(fields[i].GetValue(data));
             }
-            if (i < fields.Length - 1)
+            if (i < fields.Count() - 1)
             {
                 csvString.Append(",");
             }
@@ -178,32 +187,35 @@ public class SaveData<T>
 
     /// <summary>
     /// Return info on all public fields.
-    /// Order is: sessionNumber, sessionDate, sessionStartTime, sessionEndTime, then any
+    /// Order is: gameNumber (if present), sessionNumber, date, startTime, endTime, then any
     /// other fields in alphabetical order.
     /// </summary>
-    private FieldInfo[] GetFields(T data)
+    private List<FieldInfo> GetFields(T data)
     {
         Type type = data.GetType();
         FieldInfo[] fields = type.GetFields();
-        FieldInfo[] sortedFields = new FieldInfo[fields.Length];
+        List<FieldInfo> sortedFields = new List<FieldInfo>();
 
-        // We return session number, date, startTime, endTime first (as this is general data
-        // for all save files, and useful to have at the start of the csv)
-        sortedFields[0] = type.GetField("sessionNumber");
-        sortedFields[1] = type.GetField("sessionDate");
-        sortedFields[2] = type.GetField("sessionStartTime");
-        sortedFields[3] = type.GetField("sessionEndTime");
+        // We return the following fields first (as this is general data that is
+        // useful to have at the start of the csv)
+        string[] fieldNames = { "gameNumber", "sessionNumber", "date", "startTime", "endTime" };
+        foreach (string name in fieldNames)
+        {
+            FieldInfo field = type.GetField(name);
+            if (field is not null)
+            {
+                sortedFields.Add(field);
+            }
+        }
 
         // Then, all other fields sorted in alphabetical order
         Array.Sort(fields, (x, y) => String.Compare(x.Name, y.Name));
 
-        int nextIndex = 4;
         foreach (FieldInfo field in fields)
         {
             if (!sortedFields.Contains(field))
             {
-                sortedFields[nextIndex] = field;
-                nextIndex++;
+                sortedFields.Add(field);
             }
         }
 

--- a/projects/AstroBalance/Assets/Scripts/SaveData/SaveGameData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/SaveGameData.cs
@@ -67,4 +67,13 @@ public class SaveGameData<T> : SaveData<T>
 
         return lastNComplete;
     }
+
+    /// <summary>
+    /// Get next available game number.
+    /// </summary>
+    public int GetNextGameNumber()
+    {
+        T lastGame = GetLast();
+        return lastGame is not null ? lastGame.gameNumber + 1 : 1;
+    }
 }

--- a/projects/AstroBalance/Assets/Scripts/SaveData/SessionData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SaveData/SessionData.cs
@@ -6,7 +6,6 @@ using System.Linq;
 [System.Serializable]
 public class SessionData : Data
 {
-    public int sessionNumber;
     public int totalSessionDurationMinutes;
     public bool game1RocketLaunchPlayed = false;
     public bool game2StarCollectorPlayed = false;

--- a/projects/AstroBalance/Assets/Scripts/SpaceWalking/HeadTurnScreen.cs
+++ b/projects/AstroBalance/Assets/Scripts/SpaceWalking/HeadTurnScreen.cs
@@ -30,7 +30,7 @@ public class HeadTurnScreen : MonoBehaviour
         {
             arrowActive = false;
             gameObject.SetActive(false);
-            gameManager.NextTile();
+            gameManager.UpdateHeadTurnScore();
         }
     }
 

--- a/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingData.cs
+++ b/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingData.cs
@@ -5,6 +5,9 @@
 public class SpaceWalkingData : GameData
 {
     public int timeLimitSeconds;
+    public int gameDurationSeconds;
     public int nCompleteSteps; // one complete step = a step out + back to the centre
     public bool headTurnsActive;
+    public int nCompleteHeadTurns;
+    public int adaptiveLevel;
 }

--- a/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
@@ -263,12 +263,20 @@ public class SpaceWalkingManager : MonoBehaviour
             gameData.gameDurationSeconds = timeLimit;
         }
 
+        gameData.LogEndTime();
         gameData.nCompleteSteps = stepScore;
         gameData.headTurnsActive = headTurnsActive;
         gameData.nCompleteHeadTurns = headTurnScore;
-        gameData.LogEndTime();
+
+        int adaptiveLevel = 1 + Mathf.CeilToInt((timeLimit - minTimeLimit) / timeLimitIncrement);
+        if (timeLimit == maxTimeLimit && headTurnsActive)
+        {
+            adaptiveLevel += 1;
+        }
+        gameData.adaptiveLevel = adaptiveLevel;
 
         SaveGameData<SpaceWalkingData> saveData = new(saveFilename);
+        gameData.sessionNumber = saveData.GetNextSessionNumber();
         saveData.Save(gameData);
 
         // Update save data for this session

--- a/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
@@ -217,15 +217,36 @@ public class SpaceWalkingManager : MonoBehaviour
             headTurnScreen.gameObject.SetActive(false);
             winText.text = "Congratulations! \n \n You completed " + score + " steps";
             winScreen.SetActive(true);
-            SaveGameData();
+            SaveGameData(true);
         }
     }
 
-    private void SaveGameData()
+    private void OnDestroy()
+    {
+        // If the scene is exited early (e.g. with the exit button), then save this
+        // partial game's data
+        if (gameActive)
+        {
+            SaveGameData(false);
+        }
+    }
+
+    private void SaveGameData(bool gameComplete)
     {
         // Update save data for this game
-        gameData.gameCompleted = true;
+        gameData.gameCompleted = gameComplete;
         gameData.timeLimitSeconds = timeLimit;
+
+        float remainingTime = timer.GetTimeRemaining();
+        if (remainingTime > 0)
+        {
+            gameData.gameDurationSeconds = Mathf.FloorToInt(timeLimit - remainingTime + 0.5f);
+        }
+        else
+        {
+            gameData.gameDurationSeconds = timeLimit;
+        }
+
         gameData.nCompleteSteps = score;
         gameData.headTurnsActive = headTurnsActive;
         gameData.LogEndTime();
@@ -234,7 +255,10 @@ public class SpaceWalkingManager : MonoBehaviour
         saveData.Save(gameData);
 
         // Update save data for this session
-        CaptureSessionData.MarkGameAsPlayed("game5SpaceWalkPlayed");
+        if (gameComplete)
+        {
+            CaptureSessionData.MarkGameAsPlayed("game5SpaceWalkPlayed");
+        }
     }
 
     private void SetTimeLimit(int limit)

--- a/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
@@ -62,7 +62,8 @@ public class SpaceWalkingManager : MonoBehaviour
 
     private TextMeshProUGUI winText;
     private bool gameActive = true;
-    private int score = 0;
+    private int stepScore = 0;
+    private int headTurnScore = 0;
     private int timeLimit;
     private SpaceWalkingData gameData;
     private string saveFilename = "SpaceWalkingScores";
@@ -188,19 +189,34 @@ public class SpaceWalkingManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Increase score (successfully completed steps) by one,
+    /// Increase successfully completed steps by one,
     /// then try to start a head turn sequence.
     /// </summary>
-    public void UpdateScore()
+    public void UpdateStepScore()
     {
         if (!gameActive)
         {
             return;
         }
 
-        score += 1;
-        scoreText.text = score.ToString();
+        stepScore += 1;
+        scoreText.text = stepScore.ToString();
         HeadTurn();
+    }
+
+    /// <summary>
+    /// Increase successfully completed head turns by one,
+    /// then activate the next tile.
+    /// </summary>
+    public void UpdateHeadTurnScore()
+    {
+        if (!gameActive || !headTurnsActive)
+        {
+            return;
+        }
+
+        headTurnScore += 1;
+        NextTile();
     }
 
     public bool IsGameActive()
@@ -215,7 +231,7 @@ public class SpaceWalkingManager : MonoBehaviour
             gameActive = false;
 
             headTurnScreen.gameObject.SetActive(false);
-            winText.text = "Congratulations! \n \n You completed " + score + " steps";
+            winText.text = "Congratulations! \n \n You completed " + stepScore + " steps";
             winScreen.SetActive(true);
             SaveGameData(true);
         }
@@ -247,8 +263,9 @@ public class SpaceWalkingManager : MonoBehaviour
             gameData.gameDurationSeconds = timeLimit;
         }
 
-        gameData.nCompleteSteps = score;
+        gameData.nCompleteSteps = stepScore;
         gameData.headTurnsActive = headTurnsActive;
+        gameData.nCompleteHeadTurns = headTurnScore;
         gameData.LogEndTime();
 
         SaveGameData<SpaceWalkingData> saveData = new(saveFilename);

--- a/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
@@ -276,7 +276,8 @@ public class SpaceWalkingManager : MonoBehaviour
         gameData.adaptiveLevel = adaptiveLevel;
 
         SaveGameData<SpaceWalkingData> saveData = new(saveFilename);
-        gameData.sessionNumber = saveData.GetNextSessionNumber();
+        gameData.sessionNumber = CaptureSessionData.CurrentSessionNumber();
+        gameData.gameNumber = saveData.GetNextGameNumber();
         saveData.Save(gameData);
 
         // Update save data for this session

--- a/projects/AstroBalance/Assets/Scripts/SpaceWalking/Tile.cs
+++ b/projects/AstroBalance/Assets/Scripts/SpaceWalking/Tile.cs
@@ -18,7 +18,6 @@ public class Tile : MonoBehaviour
 
     private SpriteRenderer spriteRenderer;
     private Tracker tracker;
-    private TileManager tileManager;
     private SpaceWalkingManager gameManager;
     private GameObject selectedSparkle;
     private float headXMin;
@@ -46,7 +45,6 @@ public class Tile : MonoBehaviour
         spriteRenderer = GetComponent<SpriteRenderer>();
         tracker = FindFirstObjectByType<Tracker>();
         gameManager = FindFirstObjectByType<SpaceWalkingManager>();
-        tileManager = GetComponentInParent<TileManager>();
     }
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
@@ -120,7 +118,7 @@ public class Tile : MonoBehaviour
         {
             // If the centre tile has been selected successfully, then we have completed a
             // step in and out + the score must be updated
-            gameManager.UpdateScore();
+            gameManager.UpdateStepScore();
         }
         else
         {

--- a/projects/AstroBalance/Assets/Scripts/StarSeek/LockedOn.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarSeek/LockedOn.cs
@@ -35,7 +35,7 @@ public class LockedOn : MonoBehaviour
     }
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    void Awake()
     {
         gameManager = FindFirstObjectByType<StarSeekManager>();
 

--- a/projects/AstroBalance/Assets/Scripts/StarSeek/LockedOn.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarSeek/LockedOn.cs
@@ -34,7 +34,7 @@ public class LockedOn : MonoBehaviour
         Double,
     }
 
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    // Awake is called once when the script instance is loaded
     void Awake()
     {
         gameManager = FindFirstObjectByType<StarSeekManager>();

--- a/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekData.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekData.cs
@@ -7,4 +7,5 @@ public class StarSeekData : GameData
     public int timeLimitSeconds;
     public int gameDurationSeconds;
     public int nStarsCollected;
+    public int adaptiveLevel;
 }

--- a/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekData.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekData.cs
@@ -5,5 +5,6 @@
 public class StarSeekData : GameData
 {
     public int timeLimitSeconds;
+    public int gameDurationSeconds;
     public int nStarsCollected;
 }

--- a/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekManager.cs
@@ -168,8 +168,10 @@ public class StarSeekManager : MonoBehaviour
             gameData.gameDurationSeconds = timeLimit;
         }
 
-        gameData.nStarsCollected = score;
         gameData.LogEndTime();
+        gameData.nStarsCollected = score;
+        gameData.adaptiveLevel =
+            1 + Mathf.CeilToInt((timeLimit - minTimeLimit) / timeLimitIncrement);
 
         SaveGameData<StarSeekData> saveData = new(saveFilename);
         gameData.sessionNumber = saveData.GetNextSessionNumber();

--- a/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekManager.cs
@@ -138,23 +138,48 @@ public class StarSeekManager : MonoBehaviour
 
             winText.text = "Congratulations! \n \n You collected " + score + " stars";
             winScreen.SetActive(true);
-            SaveGameData();
+            SaveGameData(true);
         }
     }
 
-    private void SaveGameData()
+    private void OnDestroy()
+    {
+        // If the scene is exited early (e.g. with the exit button), then save this
+        // partial game's data
+        if (gameActive)
+        {
+            SaveGameData(false);
+        }
+    }
+
+    private void SaveGameData(bool gameComplete)
     {
         // Update save data for this game
-        gameData.gameCompleted = true;
+        gameData.gameCompleted = gameComplete;
         gameData.timeLimitSeconds = timeLimit;
+
+        float remainingTime = timer.GetTimeRemaining();
+        if (remainingTime > 0)
+        {
+            gameData.gameDurationSeconds = Mathf.FloorToInt(timeLimit - remainingTime + 0.5f);
+        }
+        else
+        {
+            gameData.gameDurationSeconds = timeLimit;
+        }
+
         gameData.nStarsCollected = score;
         gameData.LogEndTime();
 
         SaveGameData<StarSeekData> saveData = new(saveFilename);
+        gameData.sessionNumber = saveData.GetNextSessionNumber();
         saveData.Save(gameData);
 
         // Update save data for this session
-        CaptureSessionData.MarkGameAsPlayed("game3StarSeekPlayed");
+        if (gameComplete)
+        {
+            CaptureSessionData.MarkGameAsPlayed("game3StarSeekPlayed");
+        }
     }
 
     private void SetTimeLimit(int limit)

--- a/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekManager.cs
@@ -174,7 +174,8 @@ public class StarSeekManager : MonoBehaviour
             1 + Mathf.CeilToInt((timeLimit - minTimeLimit) / timeLimitIncrement);
 
         SaveGameData<StarSeekData> saveData = new(saveFilename);
-        gameData.sessionNumber = saveData.GetNextSessionNumber();
+        gameData.sessionNumber = CaptureSessionData.CurrentSessionNumber();
+        gameData.gameNumber = saveData.GetNextGameNumber();
         saveData.Save(gameData);
 
         // Update save data for this session


### PR DESCRIPTION
For https://github.com/UCL/AstroBalance/issues/20

This adds the required save data for star seek + space walk, as specified in the spreadsheet:
- As `sessionNumber` is present in all csv files, I moved it into the `Data` base class
- I added 'session' to the start of date / start time / end time to match `sessionNumber` (and to match the column names in the spreadsheet more closely)
- For both games, I added additional code in `OnDestroy` to ensure that partial games are saved (where the exit button is clicked early)
- As some of the fields aren't self explanatory from the column name, I thought it would be useful to expand the `docs` with information about the save data. This will be important for other mini-games who save more complex data in their `.csv` files.