### PR TITLE
Expand data for star collector game

### DIFF
--- a/docs/space-walking.md
+++ b/docs/space-walking.md
@@ -39,7 +39,7 @@ Data is saved to `SpaceWalkingScores.csv`, with one row per played game. Values 
 - `endTime`: the game end time in format HH:MM:ss (local time - see startTime description)
 - `gameCompleted`: whether this game was completed. If they exited early, this will be false.
 - `timeLimitSeconds`: the time limit set for this game in seconds
-- `gameDurationSeconds`: how long the game was played in seconds. If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.
+- `gameDurationSeconds`: how long the game was played (rounded to the nearest second). If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.
 - `nCompleteSteps`: number of completed steps during this game. One complete step = a step out and back to the centre.
 - `headTurnsActive`: whether head turn arrows were active for this game (only active at highest difficulty level)
 - `nCompleteHeadTurns`: number of completed head turns (will be 0 if `headTurnsActive` is false)

--- a/docs/star-collector.md
+++ b/docs/star-collector.md
@@ -40,7 +40,7 @@ Data is saved to `StarCollectorScores.csv`, with one row per played game. Values
 - `adaptiveLevel`: an integer (1 or above) representing the current difficulty level. Every time the game time limit is increased, this level increases by one.
 - `finalStarFallSpeed`: Speed of falling stars (unity units per second) at the end of the game.
 
-**Note**: all head speed measures below are calculated as follows. Every `samplingIntervalSeconds` (a configurable parameter in `StarCollectorManager`), all head yaw angle readings from that time period are summed together and divided by the total difference in time to give a speed in degrees per second.
+**Note**: all head speed measures below are calculated as follows. Every `samplingIntervalSeconds` (a configurable parameter in `StarCollectorManager`), the absolute differences of head yaw angle between consecutive readings in the time period are summed together and divided by the total difference in time to give a speed in degrees per second.
 If the player goes out of range at any point in those `samplingIntervalSeconds` (i.e. the tracker can no longer detect them), then that speed measurement is discarded. 
 
 At the end of the game, all sampled speed measurements are used to calculate the summary statistics below:

--- a/docs/star-collector.md
+++ b/docs/star-collector.md
@@ -5,15 +5,15 @@ top of the screen.
 
 ## Main objects / values to edit during play testing
 
-- **StarCollectorManager**: values related to the overall win condition of the game, and head velocity save data
+- **StarCollectorManager**: values related to the overall win condition of the game, and head speed save data
   - Min / max time limit in seconds
   - Time limit increment in seconds (if time limit upgrade % is met)
   - Number of games in a row that must meet the upgrade % to increase the time limit
   - The length of the time window used to evaluate player performance
   - The % of stars that must be collected to increase speed or time limit
-  - The maximum number of head yaw readings to keep in the buffer at one time (these are used for the head velocity save data)
-  - The minimum number of head yaw readings needed to calculate a head velocity
-  - The number of seconds to calculate head yaw velocity over
+  - The maximum number of head yaw readings to keep in the buffer at one time (these are used for the head speed save data)
+  - The minimum number of head yaw readings needed to calculate a head speed
+  - The number of seconds to calculate head yaw speed over
  
 - **StarGenerator**: values related to generation of the wave of stars
   - Min, max and base star speed
@@ -39,6 +39,6 @@ Data is saved to `StarCollectorScores.csv`, with one row per played game. Values
 - `percentStarsCollected`: the percent of all stars collected during the game, rounded to 2 decimal places.
 - `adaptiveLevel`: an integer (1 or above) representing the current difficulty level. Every time the game time limit is increased, this level increases by one.
 - `finalStarFallSpeed`: Speed of falling stars (unity units per second) at the end of the game.
-- `headVelocityDegPerSecMean`: Mean head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.
-- `headVelocityDegPerSecPeak`: Peak head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.
-- `headVelocityDegPerSecSD`: Standard deviation of head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.
+- `headSpeedDegPerSecMean`: Mean head yaw speed (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.
+- `headSpeedDegPerSecPeak`: Peak head yaw speed (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.
+- `headSpeedDegPerSecSD`: Standard deviation of head yaw speed (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.

--- a/docs/star-collector.md
+++ b/docs/star-collector.md
@@ -36,6 +36,6 @@ Data is saved to `StarCollectorScores.csv`, with one row per played game. Values
 - `percentStarsCollected`: the percent of all stars collected during the game, rounded to 2 decimal places.
 - `adaptiveLevel`: an integer (1 or above) representing the current difficulty level. Every time the game time limit is increased, this level increases by one.
 - `finalStarFallSpeed`: Speed of falling stars (unity units per second) at the end of the game.
-- `headVelocityDegPerSecMean`: Mean head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. 
-- `headVelocityDegPerSecPeak`: Peak head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. 
-- `headVelocityDegPerSecSD`: Standard deviation of head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. 
+- `headVelocityDegPerSecMean`: Mean head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.
+- `headVelocityDegPerSecPeak`: Peak head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.
+- `headVelocityDegPerSecSD`: Standard deviation of head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.

--- a/docs/star-collector.md
+++ b/docs/star-collector.md
@@ -22,12 +22,13 @@ top of the screen.
   
 ## Save data
 
-Data is saved to `StarCollectorScores.csv`, with one row per game session. Values are:
+Data is saved to `StarCollectorScores.csv`, with one row per played game. Values are:
 
-- `sessionNumber`: a unique id per game session
-- `sessionDate`: the date of the game session in format YYYY-MM-DD
-- `sessionStartTime`: the game start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
-- `sessionEndTime`: the game end time in format HH:MM:ss (local time - see sessionStartTime description)
+- `gameNumber`: a unique id per played star collector game
+- `sessionNumber`: the session this game was played in (corresponds to sessionNumber in [`SessionSummary.csv`](./session-summary.md))
+- `date`: the date of the game session in format YYYY-MM-DD
+- `startTime`: the game start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
+- `endTime`: the game end time in format HH:MM:ss (local time - see startTime description)
 - `gameCompleted`: whether this game was completed. If they exited early, this will be false.
 - `timeLimitSeconds`: the time limit set for this game in seconds
 - `gameDurationSeconds`: how long the game was played in seconds. If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.
@@ -35,3 +36,6 @@ Data is saved to `StarCollectorScores.csv`, with one row per game session. Value
 - `percentStarsCollected`: the percent of all stars collected during the game.
 - `adaptiveLevel`: an integer (1 or above) representing the current difficulty level. Every time the game time limit is increased, this level increases by one.
 - `finalStarFallSpeed`: Speed of falling stars (unity units per second) at the end of the game.
+- `headVelocityDegPerSecMean`: Mean head yaw velocity (left-right rotation) measured in degrees per second. 
+- `headVelocityDegPerSecPeak`: Peak head yaw velocity (left-right rotation) measured in degrees per second.
+- `headVelocityDegPerSecSD`: Standard deviation of head yaw velocity (left-right rotation) measured in degrees per second.

--- a/docs/star-collector.md
+++ b/docs/star-collector.md
@@ -5,12 +5,15 @@ top of the screen.
 
 ## Main objects / values to edit during play testing
 
-- **StarCollectorManager**: values related to the overall win condition of the game
+- **StarCollectorManager**: values related to the overall win condition of the game, and head velocity save data
   - Min / max time limit in seconds
   - Time limit increment in seconds (if time limit upgrade % is met)
   - Number of games in a row that must meet the upgrade % to increase the time limit
   - The length of the time window used to evaluate player performance
   - The % of stars that must be collected to increase speed or time limit
+  - The maximum number of head yaw readings to keep in the buffer at one time (these are used for the head velocity save data)
+  - The minimum number of head yaw readings needed to calculate a head velocity
+  - The number of seconds to calculate head yaw velocity over
  
 - **StarGenerator**: values related to generation of the wave of stars
   - Min, max and base star speed

--- a/docs/star-collector.md
+++ b/docs/star-collector.md
@@ -31,11 +31,11 @@ Data is saved to `StarCollectorScores.csv`, with one row per played game. Values
 - `endTime`: the game end time in format HH:MM:ss (local time - see startTime description)
 - `gameCompleted`: whether this game was completed. If they exited early, this will be false.
 - `timeLimitSeconds`: the time limit set for this game in seconds
-- `gameDurationSeconds`: how long the game was played in seconds. If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.
+- `gameDurationSeconds`: how long the game was played (rounded to the nearest second). If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.
 - `nStarsCollected`: the number of stars collected during the game
-- `percentStarsCollected`: the percent of all stars collected during the game.
+- `percentStarsCollected`: the percent of all stars collected during the game, rounded to 2 decimal places.
 - `adaptiveLevel`: an integer (1 or above) representing the current difficulty level. Every time the game time limit is increased, this level increases by one.
 - `finalStarFallSpeed`: Speed of falling stars (unity units per second) at the end of the game.
-- `headVelocityDegPerSecMean`: Mean head yaw velocity (left-right rotation) measured in degrees per second. 
-- `headVelocityDegPerSecPeak`: Peak head yaw velocity (left-right rotation) measured in degrees per second.
-- `headVelocityDegPerSecSD`: Standard deviation of head yaw velocity (left-right rotation) measured in degrees per second.
+- `headVelocityDegPerSecMean`: Mean head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. 
+- `headVelocityDegPerSecPeak`: Peak head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. 
+- `headVelocityDegPerSecSD`: Standard deviation of head yaw velocity (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. 

--- a/docs/star-collector.md
+++ b/docs/star-collector.md
@@ -39,6 +39,12 @@ Data is saved to `StarCollectorScores.csv`, with one row per played game. Values
 - `percentStarsCollected`: the percent of all stars collected during the game, rounded to 2 decimal places.
 - `adaptiveLevel`: an integer (1 or above) representing the current difficulty level. Every time the game time limit is increased, this level increases by one.
 - `finalStarFallSpeed`: Speed of falling stars (unity units per second) at the end of the game.
-- `headSpeedDegPerSecMean`: Mean head yaw speed (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.
-- `headSpeedDegPerSecPeak`: Peak head yaw speed (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.
-- `headSpeedDegPerSecSD`: Standard deviation of head yaw speed (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. Periods of time when the player is out of range of the tracker are excluded.
+
+**Note**: all head speed measures below are calculated as follows. Every `samplingIntervalSeconds` (a configurable parameter in `StarCollectorManager`), all head yaw angle readings from that time period are summed together and divided by the total difference in time to give a speed in degrees per second.
+If the player goes out of range at any point in those `samplingIntervalSeconds` (i.e. the tracker can no longer detect them), then that speed measurement is discarded. 
+
+At the end of the game, all sampled speed measurements are used to calculate the summary statistics below:
+
+- `headSpeedDegPerSecMean`: Mean head yaw speed (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. 
+- `headSpeedDegPerSecPeak`: Peak head yaw speed (left-right rotation) measured in degrees per second. Rounded to 2 decimal places. 
+- `headSpeedDegPerSecSD`: Standard deviation of head yaw speed (left-right rotation) measured in degrees per second. Rounded to 2 decimal places.

--- a/docs/star-collector.md
+++ b/docs/star-collector.md
@@ -19,3 +19,19 @@ top of the screen.
 
 - **Ship**: values related to ship movement
   - The amount the ship moves per degree of head movement (X By Degrees)
+  
+## Save data
+
+Data is saved to `StarCollectorScores.csv`, with one row per game session. Values are:
+
+- `sessionNumber`: a unique id per game session
+- `sessionDate`: the date of the game session in format YYYY-MM-DD
+- `sessionStartTime`: the game start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
+- `sessionEndTime`: the game end time in format HH:MM:ss (local time - see sessionStartTime description)
+- `gameCompleted`: whether this game was completed. If they exited early, this will be false.
+- `timeLimitSeconds`: the time limit set for this game in seconds
+- `gameDurationSeconds`: how long the game was played in seconds. If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.
+- `nStarsCollected`: the number of stars collected during the game
+- `percentStarsCollected`: the percent of all stars collected during the game.
+- `adaptiveLevel`: an integer (1 or above) representing the current difficulty level. Every time the game time limit is increased, this level increases by one.
+- `finalStarFallSpeed`: Speed of falling stars (unity units per second) at the end of the game.

--- a/docs/star-seek.md
+++ b/docs/star-seek.md
@@ -32,6 +32,6 @@ Data is saved to `StarSeekScores.csv`, with one row per played game. Values are:
 - `endTime`: the game end time in format HH:MM:ss (local time - see startTime description)
 - `gameCompleted`: whether this game was completed. If they exited early, this will be false.
 - `timeLimitSeconds`: the time limit set for this game in seconds
-- `gameDurationSeconds`: how long the game was played in seconds. If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.
+- `gameDurationSeconds`: how long the game was played (rounded to the nearest second). If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.
 - `nStarsCollected`: the number of stars collected during the game
 - `adaptiveLevel`: an integer (1 or above) representing the current difficulty level. Every time the time limit is increased, this level increases by one.

--- a/projects/AstroBalance/Assets/Scripts/CountdownTimer.cs
+++ b/projects/AstroBalance/Assets/Scripts/CountdownTimer.cs
@@ -67,6 +67,7 @@ public class CountdownTimer : MonoBehaviour
     {
         UpdateTimerText(0);
         timerRunning = false;
+        timeRemaining = 0;
     }
 
     /// <summary>
@@ -74,7 +75,22 @@ public class CountdownTimer : MonoBehaviour
     /// </summary>
     public float GetTimeRemaining()
     {
-        return timeRemaining;
+        if (timeRemaining < 0)
+        {
+            return 0;
+        }
+        else
+        {
+            return timeRemaining;
+        }
+    }
+
+    /// <summary>
+    /// Get elapsed time in seconds (time limit - time remaining)
+    /// </summary>
+    public float GetElapsedTime()
+    {
+        return timeLimit - GetTimeRemaining();
     }
 
     /// <summary>

--- a/projects/AstroBalance/Assets/Scripts/CountdownTimer.cs
+++ b/projects/AstroBalance/Assets/Scripts/CountdownTimer.cs
@@ -75,14 +75,7 @@ public class CountdownTimer : MonoBehaviour
     /// </summary>
     public float GetTimeRemaining()
     {
-        if (timeRemaining < 0)
-        {
-            return 0;
-        }
-        else
-        {
-            return timeRemaining;
-        }
+        return timeRemaining < 0 ? 0 : timeRemaining;
     }
 
     /// <summary>

--- a/projects/AstroBalance/Assets/Scripts/MathsUtilities.cs
+++ b/projects/AstroBalance/Assets/Scripts/MathsUtilities.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public static class MathsUtilities
@@ -10,5 +12,11 @@ public static class MathsUtilities
     public static float RoundTo2DecimalPlaces(float number)
     {
         return (float)Mathf.FloorToInt((number * 100) + 0.5f) / 100;
+    }
+
+    public static float StandardDeviation(List<float> numbers)
+    {
+        float average = numbers.Average();
+        return Mathf.Sqrt(numbers.Average(v => Mathf.Pow(v - average, 2)));
     }
 }

--- a/projects/AstroBalance/Assets/Scripts/MathsUtilities.cs
+++ b/projects/AstroBalance/Assets/Scripts/MathsUtilities.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+public static class MathsUtilities
+{
+    public static int RoundToNearestInt(float number)
+    {
+        return Mathf.FloorToInt(number + 0.5f);
+    }
+
+    public static float RoundTo2DecimalPlaces(float number)
+    {
+        return (float)Mathf.FloorToInt((number * 100) + 0.5f) / 100;
+    }
+}

--- a/projects/AstroBalance/Assets/Scripts/MathsUtilities.cs.meta
+++ b/projects/AstroBalance/Assets/Scripts/MathsUtilities.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9dd584b8c5f31594f92e67379fe26e7a

--- a/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
@@ -254,18 +254,9 @@ public class SpaceWalkingManager : MonoBehaviour
         // Update save data for this game
         gameData.gameCompleted = gameComplete;
         gameData.timeLimitSeconds = timeLimit;
-
-        float remainingTime = timer.GetTimeRemaining();
-        if (remainingTime > 0)
-        {
-            gameData.gameDurationSeconds = Mathf.FloorToInt(timeLimit - remainingTime + 0.5f);
-        }
-        else
-        {
-            gameData.gameDurationSeconds = timeLimit;
-        }
-
+        gameData.gameDurationSeconds = Mathf.FloorToInt(timer.GetElapsedTime() + 0.5f);
         gameData.LogEndTime();
+
         gameData.nCompleteSteps = stepScore;
         gameData.headTurnsActive = headTurnsActive;
         gameData.nCompleteHeadTurns = headTurnScore;

--- a/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/SpaceWalking/SpaceWalkingManager.cs
@@ -252,7 +252,7 @@ public class SpaceWalkingManager : MonoBehaviour
         // Update save data for this game
         gameData.gameCompleted = gameComplete;
         gameData.timeLimitSeconds = timeLimit;
-        gameData.gameDurationSeconds = Mathf.FloorToInt(timer.GetElapsedTime() + 0.5f);
+        gameData.gameDurationSeconds = MathsUtilities.RoundToNearestInt(timer.GetElapsedTime());
         gameData.LogEndTime();
 
         gameData.nCompleteSteps = stepScore;

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorData.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorData.cs
@@ -10,7 +10,7 @@ public class StarCollectorData : GameData
     public float percentStarsCollected;
     public int adaptiveLevel;
     public float finalStarFallSpeed;
-    public float headVelocityDegPerSecMean;
-    public float headVelocityDegPerSecPeak;
-    public float headVelocityDegPerSecSD;
+    public float headSpeedDegPerSecMean;
+    public float headSpeedDegPerSecPeak;
+    public float headSpeedDegPerSecSD;
 }

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorData.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorData.cs
@@ -9,7 +9,7 @@ public class StarCollectorData : GameData
     public int nStarsCollected;
     public float percentStarsCollected;
     public int adaptiveLevel;
-    public int finalStarFallSpeed;
+    public float finalStarFallSpeed;
     public float headVelocityDegPerSecMean;
     public float headVelocityDegPerSecPeak;
     public float headVelocityDegPerSecSD;

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorData.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorData.cs
@@ -5,6 +5,12 @@
 public class StarCollectorData : GameData
 {
     public int timeLimitSeconds;
+    public int gameDurationSeconds;
     public int nStarsCollected;
     public float percentStarsCollected;
+    public int adaptiveLevel;
+    public int finalStarFallSpeed;
+    public float headVelocityDegPerSecMean;
+    public float headVelocityDegPerSecPeak;
+    public float headVelocityDegPerSecSD;
 }

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using TMPro;
+using Tobii.GameIntegration.Net;
 using UnityEngine;
 
 public class StarCollectorManager : MonoBehaviour
@@ -49,17 +50,37 @@ public class StarCollectorManager : MonoBehaviour
     ]
     private int timeLimitUpgradePercent = 60;
 
+    [
+        SerializeField,
+        Tooltip("Maximum number of head yaw readings to keep in the buffer at one time")
+    ]
+    private int maxNItemsInBuffer = 100;
+
+    [
+        SerializeField,
+        Tooltip("The minimum number of head yaw readings needed to calculate a head velocity")
+    ]
+    private int minNItemsForVelocity = 5;
+
+    [SerializeField, Tooltip("The number of seconds to calculate head yaw velocity over")]
+    private float samplingIntervalSeconds = 0.5f;
+
     private TextMeshProUGUI winText;
+    private Tracker tracker;
     private int timeLimit;
     private int score; // stars collected over whole game
     private int missed; // stars missed over whole game
     private bool gameActive = true;
 
-    private float windowStart;
+    private float speedWindowStart; // start time of speed upgrade window
     private int scoreInTimeWindow = 0; // stars collected in time window
     private int missedInTimeWindow = 0; // stars missed in time window
     private string saveFilename = "StarCollectorScores";
     private StarCollectorData gameData;
+
+    private float bufferWindowStart; // start time of buffer update window
+    private HeadAngleBuffer headYawBuffer;
+    private List<float> headYawVelocities = new List<float>();
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
@@ -67,12 +88,16 @@ public class StarCollectorManager : MonoBehaviour
         ChooseGameTimeLimit();
 
         winText = winScreen.GetComponentInChildren<TextMeshProUGUI>();
+        tracker = FindFirstObjectByType<Tracker>();
         gameData = new StarCollectorData();
         score = 0;
         scoreText.text = score.ToString();
+
+        headYawBuffer = new HeadAngleBuffer(maxNItemsInBuffer, minNItemsForVelocity);
         timer.StartCountdown(timeLimit);
 
-        windowStart = Time.time;
+        speedWindowStart = Time.time;
+        bufferWindowStart = Time.time;
     }
 
     /// <summary>
@@ -131,9 +156,18 @@ public class StarCollectorManager : MonoBehaviour
             return;
         }
 
+        // Keep track of head yaw angles on every update
+        UpdateHeadYawBuffer();
+
+        // Every 'samplingIntervalSeconds', record the velocity averaged over that time period
+        if (Time.time - bufferWindowStart >= samplingIntervalSeconds)
+        {
+            RecordHeadVelocity();
+        }
+
         // At end of time window, assess performance and update the difficulty
         // of the game
-        if (Time.time - windowStart >= difficultyWindowSeconds)
+        if (Time.time - speedWindowStart >= difficultyWindowSeconds)
         {
             UpdateDifficulty();
         }
@@ -143,6 +177,27 @@ public class StarCollectorManager : MonoBehaviour
         {
             EndGame();
         }
+    }
+
+    /// <summary>
+    /// Add latest head yaw angle to buffer
+    /// </summary>
+    private void UpdateHeadYawBuffer()
+    {
+        HeadPose headPose = tracker.getHeadPose();
+        HeadYawItem headYaw = new HeadYawItem(headPose);
+        headYawBuffer.addIfNew(headYaw);
+    }
+
+    /// <summary>
+    /// Record the latest head yaw velocity
+    /// </summary>
+    private void RecordHeadVelocity()
+    {
+        float headVelocity = headYawBuffer.getSpeed(samplingIntervalSeconds);
+        headYawVelocities.Add(headVelocity);
+        //Debug.Log("recording head velocity" + headVelocity);
+        bufferWindowStart = Time.time;
     }
 
     /// <summary>
@@ -166,7 +221,7 @@ public class StarCollectorManager : MonoBehaviour
             starGenerator.DecreaseSpeed();
         }
 
-        windowStart = Time.time;
+        speedWindowStart = Time.time;
         scoreInTimeWindow = 0;
         missedInTimeWindow = 0;
     }
@@ -251,6 +306,13 @@ public class StarCollectorManager : MonoBehaviour
         gameData.adaptiveLevel =
             1 + Mathf.CeilToInt((timeLimit - minTimeLimit) / timeLimitIncrement);
         gameData.finalStarFallSpeed = starGenerator.GetStarSpeed();
+
+        gameData.headVelocityDegPerSecPeak = headYawVelocities.Max();
+        float average = headYawVelocities.Average();
+        gameData.headVelocityDegPerSecMean = average;
+        gameData.headVelocityDegPerSecSD = Mathf.Sqrt(
+            headYawVelocities.Average(v => Mathf.Pow(v - average, 2))
+        );
 
         SaveGameData<StarCollectorData> saveData = new(saveFilename);
         saveData.Save(gameData);

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
@@ -337,11 +337,10 @@ public class StarCollectorManager : MonoBehaviour
             gameData.headSpeedDegPerSecPeak = MathsUtilities.RoundTo2DecimalPlaces(
                 headYawSpeeds.Max()
             );
-            float average = headYawSpeeds.Average();
-            gameData.headSpeedDegPerSecMean = MathsUtilities.RoundTo2DecimalPlaces(average);
-            float standardDeviation = Mathf.Sqrt(
-                headYawSpeeds.Average(v => Mathf.Pow(v - average, 2))
+            gameData.headSpeedDegPerSecMean = MathsUtilities.RoundTo2DecimalPlaces(
+                headYawSpeeds.Average()
             );
+            float standardDeviation = MathsUtilities.StandardDeviation(headYawSpeeds);
             gameData.headSpeedDegPerSecSD = MathsUtilities.RoundTo2DecimalPlaces(standardDeviation);
         }
 

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
@@ -248,6 +248,9 @@ public class StarCollectorManager : MonoBehaviour
         float percentCollected = ((float)score / totalStars) * 100;
         gameData.nStarsCollected = score;
         gameData.percentStarsCollected = percentCollected;
+        gameData.adaptiveLevel =
+            1 + Mathf.CeilToInt((timeLimit - minTimeLimit) / timeLimitIncrement);
+        gameData.finalStarFallSpeed = starGenerator.GetStarSpeed();
 
         SaveGameData<StarCollectorData> saveData = new(saveFilename);
         saveData.Save(gameData);

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
@@ -222,26 +222,40 @@ public class StarCollectorManager : MonoBehaviour
             winScreen.SetActive(true);
 
             // Save game details to file
-            SaveGameData();
+            SaveGameData(true);
         }
     }
 
-    private void SaveGameData()
+    private void OnDestroy()
     {
+        // If the scene is exited early (e.g. with the exit button), then save this
+        // partial game's data
+        if (gameActive)
+        {
+            SaveGameData(false);
+        }
+    }
+
+    private void SaveGameData(bool gameComplete)
+    {
+        // Update save data for this game
+        gameData.gameCompleted = gameComplete;
+        gameData.timeLimitSeconds = timeLimit;
+        gameData.gameDurationSeconds = Mathf.FloorToInt(timer.GetElapsedTime() + 0.5f);
+        gameData.LogEndTime();
+
         float totalStars = score + missed;
         float percentCollected = ((float)score / totalStars) * 100;
-
-        // Update save data for this game
-        gameData.gameCompleted = true;
-        gameData.timeLimitSeconds = timeLimit;
         gameData.nStarsCollected = score;
         gameData.percentStarsCollected = percentCollected;
-        gameData.LogEndTime();
 
         SaveGameData<StarCollectorData> saveData = new(saveFilename);
         saveData.Save(gameData);
 
         // Update save data for this session
-        CaptureSessionData.MarkGameAsComplete("nCompleteStarCollectorGames");
+        if (gameComplete)
+        {
+            CaptureSessionData.MarkGameAsComplete("nCompleteStarCollectorGames");
+        }
     }
 }

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
@@ -58,11 +58,11 @@ public class StarCollectorManager : MonoBehaviour
 
     [
         SerializeField,
-        Tooltip("The minimum number of head yaw readings needed to calculate a head velocity")
+        Tooltip("The minimum number of head yaw readings needed to calculate a head speed")
     ]
-    private int minNItemsForVelocity = 5;
+    private int minNItemsForSpeed = 5;
 
-    [SerializeField, Tooltip("The number of seconds to calculate head yaw velocity over")]
+    [SerializeField, Tooltip("The number of seconds to calculate head yaw speed over")]
     private float samplingIntervalSeconds = 0.5f;
 
     private TextMeshProUGUI winText;
@@ -81,7 +81,7 @@ public class StarCollectorManager : MonoBehaviour
     private float bufferWindowStart; // start time of buffer update window
     private bool outOfRangeInWindow = false; // whether the player went out of range of the tracker during this window
     private HeadAngleBuffer headYawBuffer;
-    private List<float> headYawVelocities = new List<float>();
+    private List<float> headYawSpeeds = new List<float>();
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
     void Start()
@@ -94,7 +94,7 @@ public class StarCollectorManager : MonoBehaviour
         score = 0;
         scoreText.text = score.ToString();
 
-        headYawBuffer = new HeadAngleBuffer(maxNItemsInBuffer, minNItemsForVelocity);
+        headYawBuffer = new HeadAngleBuffer(maxNItemsInBuffer, minNItemsForSpeed);
         timer.StartCountdown(timeLimit);
 
         speedWindowStart = Time.time;
@@ -158,10 +158,10 @@ public class StarCollectorManager : MonoBehaviour
         // Keep track of head yaw angles on every update
         UpdateHeadYawBuffer();
 
-        // Every 'samplingIntervalSeconds', record the velocity averaged over that time period
+        // Every 'samplingIntervalSeconds', record the speed averaged over that time period
         if (Time.time - bufferWindowStart >= samplingIntervalSeconds)
         {
-            RecordHeadVelocity();
+            RecordHeadSpeed();
         }
 
         // At end of time window, assess performance and update the difficulty
@@ -197,21 +197,21 @@ public class StarCollectorManager : MonoBehaviour
     }
 
     /// <summary>
-    /// Record the latest head yaw velocity
+    /// Record the latest head yaw speed
     /// </summary>
-    private void RecordHeadVelocity()
+    private void RecordHeadSpeed()
     {
-        // Only record velocities if the player was in range of the tracker for the whole window.
+        // Only record speeds if the player was in range of the tracker for the whole window.
         // (otherwise, if they've been out of range for a while, we may be calculating the speed of quite old data in the buffer)
         if (!outOfRangeInWindow)
         {
-            float headVelocity = headYawBuffer.getSpeed(samplingIntervalSeconds);
+            float headSpeed = headYawBuffer.getSpeed(samplingIntervalSeconds);
 
-            // If there aren't enough recorded head yaw angles yet, the returned velocity is zero.
+            // If there aren't enough recorded head yaw angles yet, the returned speed is zero.
             // We don't want to include these readings in the overall averages.
-            if (headVelocity > 0)
+            if (headSpeed > 0)
             {
-                headYawVelocities.Add(headVelocity);
+                headYawSpeeds.Add(headSpeed);
             }
         }
 
@@ -326,25 +326,23 @@ public class StarCollectorManager : MonoBehaviour
             1 + Mathf.CeilToInt((timeLimit - minTimeLimit) / timeLimitIncrement);
         gameData.finalStarFallSpeed = starGenerator.GetStarSpeed();
 
-        if (headYawVelocities.Count() == 0)
+        if (headYawSpeeds.Count() == 0)
         {
-            gameData.headVelocityDegPerSecPeak = 0;
-            gameData.headVelocityDegPerSecMean = 0;
-            gameData.headVelocityDegPerSecSD = 0;
+            gameData.headSpeedDegPerSecPeak = 0;
+            gameData.headSpeedDegPerSecMean = 0;
+            gameData.headSpeedDegPerSecSD = 0;
         }
         else
         {
-            gameData.headVelocityDegPerSecPeak = MathsUtilities.RoundTo2DecimalPlaces(
-                headYawVelocities.Max()
+            gameData.headSpeedDegPerSecPeak = MathsUtilities.RoundTo2DecimalPlaces(
+                headYawSpeeds.Max()
             );
-            float average = headYawVelocities.Average();
-            gameData.headVelocityDegPerSecMean = MathsUtilities.RoundTo2DecimalPlaces(average);
+            float average = headYawSpeeds.Average();
+            gameData.headSpeedDegPerSecMean = MathsUtilities.RoundTo2DecimalPlaces(average);
             float standardDeviation = Mathf.Sqrt(
-                headYawVelocities.Average(v => Mathf.Pow(v - average, 2))
+                headYawSpeeds.Average(v => Mathf.Pow(v - average, 2))
             );
-            gameData.headVelocityDegPerSecSD = MathsUtilities.RoundTo2DecimalPlaces(
-                standardDeviation
-            );
+            gameData.headSpeedDegPerSecSD = MathsUtilities.RoundTo2DecimalPlaces(standardDeviation);
         }
 
         SaveGameData<StarCollectorData> saveData = new(saveFilename);

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
@@ -79,6 +79,7 @@ public class StarCollectorManager : MonoBehaviour
     private StarCollectorData gameData;
 
     private float bufferWindowStart; // start time of buffer update window
+    private bool outOfRangeInWindow = false; // whether the player went out of range of the tracker during this window
     private HeadAngleBuffer headYawBuffer;
     private List<float> headYawVelocities = new List<float>();
 
@@ -184,9 +185,17 @@ public class StarCollectorManager : MonoBehaviour
     /// </summary>
     private void UpdateHeadYawBuffer()
     {
-        HeadPose headPose = tracker.getHeadPose();
-        HeadYawItem headYaw = new HeadYawItem(headPose);
-        headYawBuffer.addIfNew(headYaw);
+        // If the player goes out of range of the tracker
+        if (!tracker.isPlayerDetected())
+        {
+            outOfRangeInWindow = true;
+        }
+        else
+        {
+            HeadPose headPose = tracker.getHeadPose();
+            HeadYawItem headYaw = new HeadYawItem(headPose);
+            headYawBuffer.addIfNew(headYaw);
+        }
     }
 
     /// <summary>
@@ -194,9 +203,21 @@ public class StarCollectorManager : MonoBehaviour
     /// </summary>
     private void RecordHeadVelocity()
     {
-        float headVelocity = headYawBuffer.getSpeed(samplingIntervalSeconds);
-        headYawVelocities.Add(headVelocity);
-        //Debug.Log("recording head velocity" + headVelocity);
+        // Only record velocities if the player was in range of the tracker for the whole window.
+        // (otherwise, if they've been out of range for a while, we may be calculating the speed of quite old data in the buffer)
+        if (!outOfRangeInWindow)
+        {
+            float headVelocity = headYawBuffer.getSpeed(samplingIntervalSeconds);
+
+            // If there aren't enough recorded head yaw angles yet, the returned velocity is zero.
+            // We don't want to include these readings in the overall averages.
+            if (headVelocity > 0)
+            {
+                headYawVelocities.Add(headVelocity);
+            }
+        }
+
+        outOfRangeInWindow = false;
         bufferWindowStart = Time.time;
     }
 
@@ -307,12 +328,21 @@ public class StarCollectorManager : MonoBehaviour
             1 + Mathf.CeilToInt((timeLimit - minTimeLimit) / timeLimitIncrement);
         gameData.finalStarFallSpeed = starGenerator.GetStarSpeed();
 
-        gameData.headVelocityDegPerSecPeak = headYawVelocities.Max();
-        float average = headYawVelocities.Average();
-        gameData.headVelocityDegPerSecMean = average;
-        gameData.headVelocityDegPerSecSD = Mathf.Sqrt(
-            headYawVelocities.Average(v => Mathf.Pow(v - average, 2))
-        );
+        if (headYawVelocities.Count() == 0)
+        {
+            gameData.headVelocityDegPerSecPeak = 0;
+            gameData.headVelocityDegPerSecMean = 0;
+            gameData.headVelocityDegPerSecSD = 0;
+        }
+        else
+        {
+            gameData.headVelocityDegPerSecPeak = headYawVelocities.Max();
+            float average = headYawVelocities.Average();
+            gameData.headVelocityDegPerSecMean = average;
+            gameData.headVelocityDegPerSecSD = Mathf.Sqrt(
+                headYawVelocities.Average(v => Mathf.Pow(v - average, 2))
+            );
+        }
 
         SaveGameData<StarCollectorData> saveData = new(saveFilename);
         saveData.Save(gameData);

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
@@ -348,6 +348,8 @@ public class StarCollectorManager : MonoBehaviour
         }
 
         SaveGameData<StarCollectorData> saveData = new(saveFilename);
+        gameData.sessionNumber = CaptureSessionData.CurrentSessionNumber();
+        gameData.gameNumber = saveData.GetNextGameNumber();
         saveData.Save(gameData);
 
         // Update save data for this session

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarCollectorManager.cs
@@ -315,13 +315,13 @@ public class StarCollectorManager : MonoBehaviour
         // Update save data for this game
         gameData.gameCompleted = gameComplete;
         gameData.timeLimitSeconds = timeLimit;
-        gameData.gameDurationSeconds = Mathf.FloorToInt(timer.GetElapsedTime() + 0.5f);
+        gameData.gameDurationSeconds = MathsUtilities.RoundToNearestInt(timer.GetElapsedTime());
         gameData.LogEndTime();
 
         float totalStars = score + missed;
         float percentCollected = ((float)score / totalStars) * 100;
         gameData.nStarsCollected = score;
-        gameData.percentStarsCollected = percentCollected;
+        gameData.percentStarsCollected = MathsUtilities.RoundTo2DecimalPlaces(percentCollected);
         gameData.adaptiveLevel =
             1 + Mathf.CeilToInt((timeLimit - minTimeLimit) / timeLimitIncrement);
         gameData.finalStarFallSpeed = starGenerator.GetStarSpeed();
@@ -334,11 +334,16 @@ public class StarCollectorManager : MonoBehaviour
         }
         else
         {
-            gameData.headVelocityDegPerSecPeak = headYawVelocities.Max();
+            gameData.headVelocityDegPerSecPeak = MathsUtilities.RoundTo2DecimalPlaces(
+                headYawVelocities.Max()
+            );
             float average = headYawVelocities.Average();
-            gameData.headVelocityDegPerSecMean = average;
-            gameData.headVelocityDegPerSecSD = Mathf.Sqrt(
+            gameData.headVelocityDegPerSecMean = MathsUtilities.RoundTo2DecimalPlaces(average);
+            float standardDeviation = Mathf.Sqrt(
                 headYawVelocities.Average(v => Mathf.Pow(v - average, 2))
+            );
+            gameData.headVelocityDegPerSecSD = MathsUtilities.RoundTo2DecimalPlaces(
+                standardDeviation
             );
         }
 

--- a/projects/AstroBalance/Assets/Scripts/StarCollector/StarGenerator.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarCollector/StarGenerator.cs
@@ -103,7 +103,7 @@ public class StarGenerator : MonoBehaviour
             baseStarSpeed = nextSpeed;
         }
 
-        Debug.Log($"Updated star speed to {nextSpeed}");
+        Debug.Log($"Updated star speed to {baseStarSpeed}");
     }
 
     public void StopGeneration()

--- a/projects/AstroBalance/Assets/Scripts/StarMap/StarMapManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarMap/StarMapManager.cs
@@ -166,7 +166,7 @@ public class StarMapManager : MonoBehaviour
         trialData.trialNumber = GetNextTrialNumber();
         trialData.responseCorrect = guessCorrect;
         trialData.sequenceLength = sequenceLength;
-        trialData.responseTimeSeconds = (float)Mathf.FloorToInt((guessTime * 100) + 0.5f) / 100; // round to 2 decimal places
+        trialData.responseTimeSeconds = MathsUtilities.RoundTo2DecimalPlaces(guessTime);
         gameData.Add(trialData);
 
         // Update score text, and end condition if guess was correct

--- a/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekManager.cs
@@ -159,18 +159,9 @@ public class StarSeekManager : MonoBehaviour
         // Update save data for this game
         gameData.gameCompleted = gameComplete;
         gameData.timeLimitSeconds = timeLimit;
-
-        float remainingTime = timer.GetTimeRemaining();
-        if (remainingTime > 0)
-        {
-            gameData.gameDurationSeconds = Mathf.FloorToInt(timeLimit - remainingTime + 0.5f);
-        }
-        else
-        {
-            gameData.gameDurationSeconds = timeLimit;
-        }
-
+        gameData.gameDurationSeconds = Mathf.FloorToInt(timer.GetElapsedTime() + 0.5f);
         gameData.LogEndTime();
+
         gameData.nStarsCollected = score;
         gameData.adaptiveLevel =
             1 + Mathf.CeilToInt((timeLimit - minTimeLimit) / timeLimitIncrement);

--- a/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekManager.cs
+++ b/projects/AstroBalance/Assets/Scripts/StarSeek/StarSeekManager.cs
@@ -157,7 +157,7 @@ public class StarSeekManager : MonoBehaviour
         // Update save data for this game
         gameData.gameCompleted = gameComplete;
         gameData.timeLimitSeconds = timeLimit;
-        gameData.gameDurationSeconds = Mathf.FloorToInt(timer.GetElapsedTime() + 0.5f);
+        gameData.gameDurationSeconds = MathsUtilities.RoundToNearestInt(timer.GetElapsedTime());
         gameData.LogEndTime();
 
         gameData.nStarsCollected = score;

--- a/projects/AstroBalance/Assets/Scripts/TrackerBuffers.cs
+++ b/projects/AstroBalance/Assets/Scripts/TrackerBuffers.cs
@@ -37,7 +37,7 @@ class HeadAngleBuffer : TobiiBuffer<HeadAngleItem>
 
     private float calculateAverageSpeed(List<HeadAngleItem> headAngles)
     {
-        if (headAngles.Count() < 2)
+        if (headAngles.Count() < minDataRequired)
         {
             return 0f;
         }
@@ -224,7 +224,7 @@ class TobiiBuffer<T>
     protected int lastAddedIndex;
     private bool hasData; // flag to indicate if the buffer has any data
     protected bool hasEnoughData; // flag to indicate if the buffer has enough data to calculate speed or steadiness.
-    private int minDataRequired;
+    protected int minDataRequired;
     protected T[] buffer;
 
     /// <summary>

--- a/projects/AstroBalance/Assets/Scripts/TrackerBuffers.cs
+++ b/projects/AstroBalance/Assets/Scripts/TrackerBuffers.cs
@@ -22,7 +22,7 @@ class HeadAngleBuffer : TobiiBuffer<HeadAngleItem>
     /// Divided by the total change in time returned by TimeStampMicroSeconds
     /// </summary>
     /// <param name="speedTime">The time period in seconds over which to calculate the average speed.</param>
-    /// <returns>The average speed of the buffer over the given time period.</returns>
+    /// <returns>The average speed of the buffer over the given time period (in degrees per second)</returns>
     public float getSpeed(float speedTime)
     {
         float averageSpeed = 0f;


### PR DESCRIPTION
For https://github.com/UCL/AstroBalance/issues/20

Expands star collector saved data with various measures including mean / peak / standard deviation of head yaw velocity. Relevant docs have been updated to match.

I had to add special handling for periods when the player goes out of range of the tracker. For example, if the player plays for 10 seconds, then walks away from the computer for the remaining 50 seconds of the game, `getSpeed` on `HeadAngleBuffer` will keep reporting the speed based on data from the first 10 seconds. The issue is that when the player is out of range, the tracker will not report any new data, so the buffer remains full of old data. When you request the speed based on the last 0.5 seconds (for example), it uses the timestamp of the last item in the buffer and counts back 0.5 seconds - so it keeps using old data collected much longer than 0.5 seconds ago. 

Ideally, we could update the buffer so that it always counts back from the current timestamp (rather than the last timestamp in the buffer), but I couldn't find a way to get the current timestamp from the tracker when the player is un-detected, or an easy way to interpret the Tobii timestamps (as they aren't in isoformat). We could add our own isoformat timestamps to allow this, but wasn't sure if it was worth the extra code (as we would still need to keep the tobii timestamp too to ensure we aren't adding the same item multiple times). For now, I exclude any time periods where the player has gone out of range at any point. Any other suggestions very welcome!