### PR TITLE
Expand rocket launch data

### DIFF
--- a/docs/rocket-launch.md
+++ b/docs/rocket-launch.md
@@ -49,4 +49,4 @@ Data is saved to `RocketLaunchScores.csv`, with one row per played game. Values 
 - `gameCompleted`: whether this game was completed. If they exited early, this will be false.
 - `headMovementPlane`: the direction of head movement - either 'pitch' (up-down movement) or 'yaw' (left-right movement).
 - `launchTimeSeconds`: the number of seconds the player had to keep their eyes steady on the target while moving their head at the required speed to launch the rocket. Rounded to 2 decimal places.
-- `gameDurationSeconds`: how long the game was played (rounded to the nearest second). If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.
+- `gameDurationSeconds`: how long the game was played (rounded to the nearest second). If the player exited before the game finished, this will be less than launchTimeSeconds; if they played the game through to completion it will be longer than launchTimeSeconds (as this includes time when the player wasn't looking at the target / wasn't moving their head fast enough etc.)

--- a/docs/rocket-launch.md
+++ b/docs/rocket-launch.md
@@ -65,3 +65,5 @@ Data is saved to `RocketLaunchScores.csv`, with one row per played game. Values 
 - `headMovementPlane`: the direction of head movement - either 'pitch' (up-down movement) or 'yaw' (left-right movement).
 - `launchTimeSeconds`: the number of seconds the player had to keep their eyes steady on the target while moving their head at the required speed to launch the rocket. Rounded to 2 decimal places.
 - `gameDurationSeconds`: how long the game was played (rounded to the nearest second). If the player exited before the game finished, this will be less than launchTimeSeconds; if they played the game through to completion it will be longer than launchTimeSeconds (as this includes time when the player wasn't looking at the target / wasn't moving their head fast enough etc.)
+- `minimumHeadSpeed`: the minimum head speed required (while looking at the target) to reduce the launch timer.
+- `gazeTolerance`: the maximum number of unity units the gaze can be from the centre of the target, and still be counted as 'on target'. Rounded to 2 decimal places.

--- a/docs/rocket-launch.md
+++ b/docs/rocket-launch.md
@@ -21,10 +21,14 @@ then a timer decrements until launch time is achieved.
     - Max previous games: The maximum number of previous games to retrieve to determine experience based difficulty
     - Adaptive difficulty: integer describing level of adaptive difficulty - higher numbers are more difficult.
 
+  - **Save data variables**
+    - Sampling interval: the interval in seconds between samples for the save data. 
+
   - **User Interface Items**:
     - Count down sprites: A list of sprites to use for the count down code display.
     - Instructions Text: A text box to place the instruction text.
     - Win Screen: Screen to show a successful launch.
+  
   - **Launch Speed Variables**: Control rocket behaviour at launch.
     - acceleration: The acceleration of the rocket when it launches.
   
@@ -72,7 +76,7 @@ Data is saved to `RocketLaunchScores.csv`, with one row per played game. Values 
 
 - Head speed: the absolute differences of head angle between consecutive readings in the time period are summed together and divided by the total difference in time to give a speed in degrees per second.
 
-- Gaze steady: a boolean value (either true or false). It will be true if the average distance between all gaze positions in the time period and the centre of the target is less than `gazeTolerance`.
+- Gaze steady: a boolean value (either true or false). It will be true if gaze positions in the time period are (on average) less than `gazeTolerance` from the centre of the target.
 
 If the player goes out of range at any point in those `samplingIntervalSeconds` (i.e. the tracker can no longer detect them), then the samples for that time period are discarded. 
 

--- a/docs/rocket-launch.md
+++ b/docs/rocket-launch.md
@@ -67,3 +67,26 @@ Data is saved to `RocketLaunchScores.csv`, with one row per played game. Values 
 - `gameDurationSeconds`: how long the game was played (rounded to the nearest second). If the player exited before the game finished, this will be less than launchTimeSeconds; if they played the game through to completion it will be longer than launchTimeSeconds (as this includes time when the player wasn't looking at the target / wasn't moving their head fast enough etc.)
 - `minimumHeadSpeed`: the minimum head speed required (while looking at the target) to reduce the launch timer.
 - `gazeTolerance`: the maximum number of unity units the gaze can be from the centre of the target, and still be counted as 'on target'. Rounded to 2 decimal places.
+
+**Note**: all measures below are calculated as follows. Every `samplingIntervalSeconds` (a configurable parameter in `LaunchControl`), both a head speed and gaze steady sample are taken. 
+
+- Head speed: the absolute differences of head angle between consecutive readings in the time period are summed together and divided by the total difference in time to give a speed in degrees per second.
+
+- Gaze steady: a boolean value (either true or false). It will be true if the average distance between all gaze positions in the time period and the centre of the target is less than `gazeTolerance`.
+
+If the player goes out of range at any point in those `samplingIntervalSeconds` (i.e. the tracker can no longer detect them), then the samples for that time period are discarded. 
+
+At the end of the game, all samples are used to calculate the summary statistics below:
+
+- `headSpeedDegPerSecMean`: Mean head rotation speed measured in degrees per second (on `headMovementPlane` - either pitch or yaw). Rounded to 2 decimal places. 
+- `headSpeedDegPerSecPeak`: Peak head head rotation speed measured in degrees per second (on `headMovementPlane` - either pitch or yaw). Rounded to 2 decimal places. 
+- `headSpeedDegPerSecMedian`: Median head rotation speed measured in degrees per second (on `headMovementPlane` - either pitch or yaw). Rounded to 2 decimal places. 
+- `headSpeedDegPerSecSD`: Standard deviation of head rotation speed measured in degrees per second (on `headMovementPlane` - either pitch or yaw). Rounded to 2 decimal places.
+- `percentTimeAbove40DegPerSec` - percentage of time with head speed over 40 degrees per second. Rounded to 2 decimal places.
+- `percentTimeGazeOnTarget` - percentage of time with gaze on target (this is the percentage of samples with `gaze steady = true` as described above). Rounded to 2 decimal places.
+
+For the adaptation window values below, this is calculated as the number of speed samples in the given range multiplied by the sampling interval in seconds:
+- `timeInAdaptationWindow1` - number of seconds with `60 <= head speed < 90` degrees per second. Rounded to 2 decimal places.
+- `timeInAdaptationWindow2` - number of seconds with `90 <= head speed < 130` degrees per second. Rounded to 2 decimal places.
+- `timeInAdaptationWindow3` - number of seconds with `130 <= head speed < 180` degrees per second. Rounded to 2 decimal places.
+- `timeInAdaptationWindow4` - number of seconds with `head speed > 180` degrees per second. Rounded to 2 decimal places.

--- a/docs/rocket-launch.md
+++ b/docs/rocket-launch.md
@@ -11,10 +11,13 @@ then a timer decrements until launch time is achieved.
   - **Head Movement Variables**: Determine the amount of head movement required to decrement the timer.
     - Head Pose Buffer Capacity (n) and speed time (s): head speed is measured as the average change in pitch or yaw over the time period speed time. The buffer will need to be sufficiently large to support the time based on game frame rate.
     - Minimum head speed (pitch or yaw) required to reduce the launch timer. The yaw speed is set higher than pitch, because it is possible (for me at least) to shake my head quicker than I can nod.
+    - Minimum n items: the minimum number of head pose readings used to calculate a head speed
+  
   - **Steady Gaze Variables**: Determine how steady the gave must be to decrement the timer.
     - Timer Duration: How long (in seconds) the player must maintain a steady gaze to increment the count down code display.
     - Gaze Pose Buffer Capacity (n) and gaze time (s), gaze steadiness is measured as the standard deviation of gaze over gaze time seconds. The buffer will need to be sufficiently large to support the time based on game frame rate.
     - Gaze Tolerance - the allowable gaze standard deviation to be steady. Smaller number will require steadier gaze. This may be reduced by the adaptive difficulty settings below.
+    - Minimum n items: the minimum number of gaze points used to calculate steadiness.
     - Target Object - if this is set you are required to look at that object, if not gaze can be anywhere on screen but must be steady. The size of the target object will be matched to the gaze tolerance.
 
   - **Adaptive difficulty variables**

--- a/docs/rocket-launch.md
+++ b/docs/rocket-launch.md
@@ -35,3 +35,18 @@ then a timer decrements until launch time is achieved.
 
 - **SmokeController**: Attached to ground left/right emitter.
   - Smoke Emission Scale: A larger value will increase the amount of smoke emitted for a given head speed.
+
+
+## Save data
+
+Data is saved to `RocketLaunchScores.csv`, with one row per played game. Values are:
+
+- `gameNumber`: a unique id per played rocket launch game
+- `sessionNumber`: the session this game was played in (corresponds to sessionNumber in [`SessionSummary.csv`](./session-summary.md))
+- `date`: the date of the game session in format YYYY-MM-DD
+- `startTime`: the game start time in format HH:MM:ss. This is the local time (e.g. if your computer is set to UK time - this is UK time).
+- `endTime`: the game end time in format HH:MM:ss (local time - see startTime description)
+- `gameCompleted`: whether this game was completed. If they exited early, this will be false.
+- `headMovementPlane`: the direction of head movement - either 'pitch' (up-down movement) or 'yaw' (left-right movement).
+- `launchTimeSeconds`: the number of seconds the player had to keep their eyes steady on the target while moving their head at the required speed to launch the rocket. Rounded to 2 decimal places.
+- `gameDurationSeconds`: how long the game was played (rounded to the nearest second). If the game was played through to completion this will be equal to timeLimitSeconds; if they exited early, it will be less.

--- a/docs/rocket-launch.md
+++ b/docs/rocket-launch.md
@@ -23,6 +23,7 @@ then a timer decrements until launch time is achieved.
 
   - **Save data variables**
     - Sampling interval: the interval in seconds between samples for the save data. 
+    - Write sampled speed: whether to write sampled speeds for this game to a text file (rocket-speeds.txt)
 
   - **User Interface Items**:
     - Count down sprites: A list of sprites to use for the count down code display.

--- a/docs/rocket-launch.md
+++ b/docs/rocket-launch.md
@@ -72,7 +72,7 @@ Data is saved to `RocketLaunchScores.csv`, with one row per played game. Values 
 - `gameCompleted`: whether this game was completed. If they exited early, this will be false.
 - `headMovementPlane`: the direction of head movement - either 'pitch' (up-down movement) or 'yaw' (left-right movement).
 - `launchTimeSeconds`: the number of seconds the player had to keep their eyes steady on the target while moving their head at the required speed to launch the rocket. Rounded to 2 decimal places.
-- `gameDurationSeconds`: how long the game was played (rounded to the nearest second). If the player exited before the game finished, this will be less than launchTimeSeconds; if they played the game through to completion it will be longer than launchTimeSeconds (as this includes time when the player wasn't looking at the target / wasn't moving their head fast enough etc.)
+- `gameDurationSeconds`: how long the game was played (rounded to the nearest second). If the player exited before the game finished, this may be less than launchTimeSeconds; if they played the game through to completion it may be longer than launchTimeSeconds (as this includes time when the player wasn't looking at the target / wasn't moving their head fast enough etc.)
 - `minimumHeadSpeed`: the minimum head speed required (while looking at the target) to reduce the launch timer.
 - `gazeTolerance`: the maximum number of unity units the gaze can be from the centre of the target, and still be counted as 'on target'. Rounded to 2 decimal places.
 

--- a/docs/rocket-launch.md
+++ b/docs/rocket-launch.md
@@ -72,25 +72,27 @@ Data is saved to `RocketLaunchScores.csv`, with one row per played game. Values 
 - `minimumHeadSpeed`: the minimum head speed required (while looking at the target) to reduce the launch timer.
 - `gazeTolerance`: the maximum number of unity units the gaze can be from the centre of the target, and still be counted as 'on target'. Rounded to 2 decimal places.
 
-**Note**: all measures below are calculated as follows. Every `samplingIntervalSeconds` (a configurable parameter in `LaunchControl`), both a head speed and gaze steady sample are taken. 
-
-- Head speed: the absolute differences of head angle between consecutive readings in the time period are summed together and divided by the total difference in time to give a speed in degrees per second.
+**Note**: all measures below are calculated as follows. Every `samplingIntervalSeconds` (a configurable parameter in `LaunchControl`), a gaze steady sample is taken: 
 
 - Gaze steady: a boolean value (either true or false). It will be true if gaze positions in the time period are (on average) less than `gazeTolerance` from the centre of the target.
 
-If the player goes out of range at any point in those `samplingIntervalSeconds` (i.e. the tracker can no longer detect them), then the samples for that time period are discarded. 
+If `gaze steady = true`, a head speed sample is also taken:
+
+- Head speed: the absolute differences of head angle between consecutive readings in the time period are summed together and divided by the total difference in time to give a speed in degrees per second.
+
+If the player goes out of range at any point in those `samplingIntervalSeconds` (i.e. the tracker can no longer detect them), then all samples for that time period are discarded. 
 
 At the end of the game, all samples are used to calculate the summary statistics below:
 
-- `headSpeedDegPerSecMean`: Mean head rotation speed measured in degrees per second (on `headMovementPlane` - either pitch or yaw). Rounded to 2 decimal places. 
-- `headSpeedDegPerSecPeak`: Peak head head rotation speed measured in degrees per second (on `headMovementPlane` - either pitch or yaw). Rounded to 2 decimal places. 
-- `headSpeedDegPerSecMedian`: Median head rotation speed measured in degrees per second (on `headMovementPlane` - either pitch or yaw). Rounded to 2 decimal places. 
-- `headSpeedDegPerSecSD`: Standard deviation of head rotation speed measured in degrees per second (on `headMovementPlane` - either pitch or yaw). Rounded to 2 decimal places.
-- `percentTimeAbove40DegPerSec` - percentage of time with head speed over 40 degrees per second. Rounded to 2 decimal places.
-- `percentTimeGazeOnTarget` - percentage of time with gaze on target (this is the percentage of samples with `gaze steady = true` as described above). Rounded to 2 decimal places.
+- `headSpeedDegPerSecMean`: Mean head rotation speed while the gaze is on target, measured in degrees per second. Rounded to 2 decimal places. 
+- `headSpeedDegPerSecPeak`: Peak head head rotation speed while the gaze is on target, measured in degrees per second. Rounded to 2 decimal places. 
+- `headSpeedDegPerSecMedian`: Median head rotation speed while the gaze is on target, measured in degrees per second. Rounded to 2 decimal places. 
+- `headSpeedDegPerSecSD`: Standard deviation of head rotation speed while the gaze is on target, measured in degrees per second. Rounded to 2 decimal places.
+- `percentTimeAbove40DegPerSec` - the % of on-target time, that the head speed was over 40 degrees per second. (this is the % of speed samples that were >40 - speed samples are _only_ taken when the gaze is on target). Rounded to 2 decimal places.
+- `percentTimeGazeOnTarget` - the % of time with gaze on target (this is the % of samples with `gaze steady = true` as described above). Rounded to 2 decimal places.
 
 For the adaptation window values below, this is calculated as the number of speed samples in the given range multiplied by the sampling interval in seconds:
-- `timeInAdaptationWindow1` - number of seconds with `60 <= head speed < 90` degrees per second. Rounded to 2 decimal places.
-- `timeInAdaptationWindow2` - number of seconds with `90 <= head speed < 130` degrees per second. Rounded to 2 decimal places.
-- `timeInAdaptationWindow3` - number of seconds with `130 <= head speed < 180` degrees per second. Rounded to 2 decimal places.
-- `timeInAdaptationWindow4` - number of seconds with `head speed > 180` degrees per second. Rounded to 2 decimal places.
+- `timeInAdaptationWindow1` - number of seconds with `60 <= head speed < 90` degrees per second and gaze on target. Rounded to 2 decimal places.
+- `timeInAdaptationWindow2` - number of seconds with `90 <= head speed < 130` degrees per second and gaze on target. Rounded to 2 decimal places.
+- `timeInAdaptationWindow3` - number of seconds with `130 <= head speed < 180` degrees per second and gaze on target. Rounded to 2 decimal places.
+- `timeInAdaptationWindow4` - number of seconds with `head speed > 180` degrees per second and gaze on target. Rounded to 2 decimal places.

--- a/projects/AstroBalance/Assets/Scenes/RocketLaunch.unity
+++ b/projects/AstroBalance/Assets/Scenes/RocketLaunch.unity
@@ -21571,6 +21571,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8902890511493098178, guid: 00c1b36d25d21214eb8e6df02c079dea, type: 3}
+      propertyPath: writeSampledSpeeds
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8902890511493098178, guid: 00c1b36d25d21214eb8e6df02c079dea, type: 3}
       propertyPath: headPoseBufferCapacity
       value: 100
       objectReference: {fileID: 0}

--- a/projects/AstroBalance/Assets/Scenes/RocketLaunch.unity
+++ b/projects/AstroBalance/Assets/Scenes/RocketLaunch.unity
@@ -21548,7 +21548,7 @@ PrefabInstance:
       objectReference: {fileID: 522649600}
     - target: {fileID: 8902890511493098178, guid: 00c1b36d25d21214eb8e6df02c079dea, type: 3}
       propertyPath: gazeTolerance
-      value: 300
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 8902890511493098178, guid: 00c1b36d25d21214eb8e6df02c079dea, type: 3}
       propertyPath: gazeStatusText

--- a/projects/AstroBalance/Assets/Scripts/MathsUtilities.cs
+++ b/projects/AstroBalance/Assets/Scripts/MathsUtilities.cs
@@ -19,4 +19,21 @@ public static class MathsUtilities
         float average = numbers.Average();
         return Mathf.Sqrt(numbers.Average(v => Mathf.Pow(v - average, 2)));
     }
+
+    public static float Median(List<float> numbers)
+    {
+        List<float> sortedList = new List<float>(numbers);
+        sortedList.Sort();
+
+        int size = sortedList.Count();
+        int midPoint = size / 2;
+
+        // Take middle value, or average of the two middle values if there's an even number of items
+        float median =
+            (size % 2 != 0)
+                ? sortedList[midPoint]
+                : (sortedList[midPoint] + sortedList[midPoint - 1]) / 2;
+
+        return median;
+    }
 }

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -351,7 +351,7 @@ public class LaunchControl : MonoBehaviour
             gameData.headMovementPlane = "yaw";
         }
 
-        gameData.launchTimeSeconds = launchTime;
+        gameData.launchTimeSeconds = MathsUtilities.RoundTo2DecimalPlaces(launchTime);
         gameData.LogEndTime();
 
         SaveGameData<RocketLaunchData> saveData = new(saveFilename);

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -292,6 +292,10 @@ public class LaunchControl : MonoBehaviour
         }
     }
 
+    /// <summary>
+    /// Take samples for head speed / gaze steady for the save data.
+    /// Windows including out of range time are excluded.
+    /// </summary>
     private void SampleForSaveData()
     {
         if (timeToNextSample > 0)
@@ -520,6 +524,7 @@ public class LaunchControl : MonoBehaviour
             gameData.headSpeedDegPerSecMedian = 0;
             gameData.headSpeedDegPerSecSD = 0;
             gameData.percentTimeAbove40DegPerSec = 0;
+            gameData.percentTimeGazeOnTarget = 0;
             gameData.timeInAdaptationWindow1 = 0;
             gameData.timeInAdaptationWindow2 = 0;
             gameData.timeInAdaptationWindow3 = 0;

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -365,6 +365,10 @@ public class LaunchControl : MonoBehaviour
         return Mathf.Max(0, currentSpeed); // Clamp to zero to avoid negative speeds
     }
 
+    /// <summary>
+    /// Calculate whether the gaze is steady
+    /// </summary>
+    /// <param name="timeSeconds">The number of seconds of data to use</param>
     private bool CalculateGazeSteady(float timeSeconds)
     {
         bool gazeIsSteady = false;

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -306,16 +306,17 @@ public class LaunchControl : MonoBehaviour
 
         if (!outOfRange && secondsSinceLastOutOfRange >= samplingIntervalSeconds)
         {
-            float speedSample = CalculateHeadSpeed(samplingIntervalSeconds, false);
-            if (speedSample > 0)
-            {
-                headSpeedSamples.Add(speedSample);
-            }
-
             bool gazeSample = CalculateGazeSteady(samplingIntervalSeconds);
             if (gazeSample)
             {
                 nSamplesGazeSteady++;
+
+                // Only record head speeds while the player's gaze is on target
+                float speedSample = CalculateHeadSpeed(samplingIntervalSeconds, false);
+                if (speedSample > 0)
+                {
+                    headSpeedSamples.Add(speedSample);
+                }
             }
             else
             {

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -133,14 +133,15 @@ public class LaunchControl : MonoBehaviour
         gazeTolerance /= adaptiveDifficulty;
         launchTime *= adaptiveDifficulty;
 
-        if (lastGameData.Count() == 0)
+        if (lastGameData.Count() == 0 || lastGameData.Last().headMovementPlane == "yaw")
         {
             usePitch = true;
         }
         else
         {
-            usePitch = !lastGameData.Last().pitch;
+            usePitch = false;
         }
+
         headPoseBuffer = new HeadPoseBuffer(headPoseBufferCapacity, minDataRequired);
         instructionsText.text = usePitch
             ? "Nod your head and repeat the code to launch the rocket!"
@@ -341,11 +342,21 @@ public class LaunchControl : MonoBehaviour
     {
         // Update save data for this game
         gameData.gameCompleted = gameComplete;
-        gameData.pitch = usePitch;
+        if (usePitch)
+        {
+            gameData.headMovementPlane = "pitch";
+        }
+        else
+        {
+            gameData.headMovementPlane = "yaw";
+        }
+
         gameData.launchTimeSeconds = launchTime;
         gameData.LogEndTime();
 
         SaveGameData<RocketLaunchData> saveData = new(saveFilename);
+        gameData.sessionNumber = CaptureSessionData.CurrentSessionNumber();
+        gameData.gameNumber = saveData.GetNextGameNumber();
         saveData.Save(gameData);
 
         // Update save data for this session

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -363,7 +363,9 @@ public class LaunchControl : MonoBehaviour
         TimeSpan gameDuration = DateTime
             .Parse(gameData.endTime)
             .Subtract(DateTime.Parse(gameData.startTime));
-        gameData.gameDurationSeconds = gameDuration.Seconds;
+        gameData.gameDurationSeconds = MathsUtilities.RoundToNearestInt(
+            (float)gameDuration.TotalSeconds
+        );
 
         SaveGameData<RocketLaunchData> saveData = new(saveFilename);
         gameData.sessionNumber = CaptureSessionData.CurrentSessionNumber();

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -497,6 +497,11 @@ public class LaunchControl : MonoBehaviour
             gameData.headSpeedDegPerSecMean = 0;
             gameData.headSpeedDegPerSecMedian = 0;
             gameData.headSpeedDegPerSecSD = 0;
+            gameData.percentTimeAbove40DegPerSec = 0;
+            gameData.timeInAdaptationWindow1 = 0;
+            gameData.timeInAdaptationWindow2 = 0;
+            gameData.timeInAdaptationWindow3 = 0;
+            gameData.timeInAdaptationWindow4 = 0;
         }
         else
         {
@@ -510,21 +515,57 @@ public class LaunchControl : MonoBehaviour
             gameData.headSpeedDegPerSecMedian = MathsUtilities.RoundTo2DecimalPlaces(median);
             float standardDeviation = MathsUtilities.StandardDeviation(headSpeedSamples);
             gameData.headSpeedDegPerSecSD = MathsUtilities.RoundTo2DecimalPlaces(standardDeviation);
-        }
 
-        int nSamplesAbove40DegPerSec = 0;
-        foreach (float headSpeed in headSpeedSamples)
-        {
-            if (headSpeed > 40)
+            int nSamplesAbove40DegPerSec = 0;
+            int nSamplesAdaptationWindow1 = 0;
+            int nSamplesAdaptationWindow2 = 0;
+            int nSamplesAdaptationWindow3 = 0;
+            int nSamplesAdaptationWindow4 = 0;
+
+            foreach (float headSpeed in headSpeedSamples)
             {
-                nSamplesAbove40DegPerSec++;
+                if (headSpeed > 40)
+                {
+                    nSamplesAbove40DegPerSec++;
+                }
+
+                if (headSpeed >= 60 && headSpeed < 90)
+                {
+                    nSamplesAdaptationWindow1++;
+                }
+                else if (headSpeed >= 90 && headSpeed < 130)
+                {
+                    nSamplesAdaptationWindow2++;
+                }
+                else if (headSpeed >= 130 && headSpeed < 180)
+                {
+                    nSamplesAdaptationWindow3++;
+                }
+                else if (headSpeed >= 180)
+                {
+                    nSamplesAdaptationWindow4++;
+                }
             }
+
+            float percentTimeAbove40DegPerSec =
+                (nSamplesAbove40DegPerSec / headSpeedSamples.Count()) * 100;
+            gameData.percentTimeAbove40DegPerSec = MathsUtilities.RoundTo2DecimalPlaces(
+                percentTimeAbove40DegPerSec
+            );
+
+            gameData.timeInAdaptationWindow1 = MathsUtilities.RoundTo2DecimalPlaces(
+                nSamplesAdaptationWindow1 * samplingIntervalSeconds
+            );
+            gameData.timeInAdaptationWindow2 = MathsUtilities.RoundTo2DecimalPlaces(
+                nSamplesAdaptationWindow2 * samplingIntervalSeconds
+            );
+            gameData.timeInAdaptationWindow3 = MathsUtilities.RoundTo2DecimalPlaces(
+                nSamplesAdaptationWindow3 * samplingIntervalSeconds
+            );
+            gameData.timeInAdaptationWindow4 = MathsUtilities.RoundTo2DecimalPlaces(
+                nSamplesAdaptationWindow4 * samplingIntervalSeconds
+            );
         }
-        float percentTimeAbove40DegPerSec =
-            (nSamplesAbove40DegPerSec / headSpeedSamples.Count()) * 100;
-        gameData.percentTimeAbove40DegPerSec = MathsUtilities.RoundTo2DecimalPlaces(
-            percentTimeAbove40DegPerSec
-        );
 
         SaveGameData<RocketLaunchData> saveData = new(saveFilename);
         gameData.sessionNumber = CaptureSessionData.CurrentSessionNumber();

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -20,16 +20,16 @@ public class LaunchControl : MonoBehaviour
     [SerializeField, Tooltip("The time in seconds to measure head speed over.")]
     private float speedTime = 2.0f;
 
-    [SerializeField, Tooltip("The minimum head speed required to reduce the launch timer.")]
-    private float minimumSpeed = 20;
+    [SerializeField, Tooltip("The minimum head pitch speed required to reduce the launch timer.")]
+    private float minimumSpeedPitch = 20;
 
     [
         SerializeField,
         Tooltip(
-            "A pitch/yaw scale factor, as in general I can shake my head faster than I can nod."
+            "The minimum head yaw speed required to reduce the launch timer. This is set higher than for pitch, as in general I can shake my head faster than I can nod"
         )
     ]
-    private float shakeSpeedReduction = 0.5f;
+    private float minimumSpeedYaw = 40;
 
     [Header("Steady Gaze Variables")]
     [SerializeField, Tooltip("Time between new random numbers in seconds.")]
@@ -96,10 +96,11 @@ public class LaunchControl : MonoBehaviour
     // head speed parameters
     private HeadPoseBuffer headPoseBuffer;
     private bool usePitch; //true if we're using pitch speed, false if we're using yaw speed.
+    private float minimumSpeed; // minimum head speed required for this game
+    private float headSpeed; // current head speed
     private RocketLaunchData gameData;
     private float rocketSpeed;
     private int minDataRequired = 2; // we need at least 2 data points to calculate a speed or steadiness
-    private float headSpeed;
     private float mouseToGazeScale = 10f; // if we're debugging using the mouse the reported speeds are much higher than with gaze.
 
     // gaze steadiness paraemeters
@@ -136,10 +137,12 @@ public class LaunchControl : MonoBehaviour
         if (lastGameData.Count() == 0 || lastGameData.Last().headMovementPlane == "yaw")
         {
             usePitch = true;
+            minimumSpeed = minimumSpeedPitch;
         }
         else
         {
             usePitch = false;
+            minimumSpeed = minimumSpeedYaw;
         }
 
         headPoseBuffer = new HeadPoseBuffer(headPoseBufferCapacity, minDataRequired);
@@ -183,10 +186,8 @@ public class LaunchControl : MonoBehaviour
             else
             {
                 headSpeed =
-                    (
-                        headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Yaw)
-                        - headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Pitch)
-                    ) * shakeSpeedReduction;
+                    headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Yaw)
+                    - headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Pitch);
             }
             headSpeed = Mathf.Max(0, headSpeed); // Clamp to zero to avoid negative speeds
 
@@ -352,6 +353,8 @@ public class LaunchControl : MonoBehaviour
         }
 
         gameData.launchTimeSeconds = MathsUtilities.RoundTo2DecimalPlaces(launchTime);
+        gameData.gazeTolerance = MathsUtilities.RoundTo2DecimalPlaces(gazeTolerance);
+        gameData.minimumHeadSpeed = MathsUtilities.RoundTo2DecimalPlaces(minimumSpeed);
         gameData.LogEndTime();
 
         SaveGameData<RocketLaunchData> saveData = new(saveFilename);

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using TMPro;
@@ -357,6 +358,13 @@ public class LaunchControl : MonoBehaviour
         gameData.minimumHeadSpeed = MathsUtilities.RoundTo2DecimalPlaces(minimumSpeed);
         gameData.LogEndTime();
 
+        // There's no overall timer for this game, so we instead use the logged start / end
+        // time (HH:mm:ss) to estimate the game duration.
+        TimeSpan gameDuration = DateTime
+            .Parse(gameData.endTime)
+            .Subtract(DateTime.Parse(gameData.startTime));
+        gameData.gameDurationSeconds = gameDuration.Seconds;
+
         SaveGameData<RocketLaunchData> saveData = new(saveFilename);
         gameData.sessionNumber = CaptureSessionData.CurrentSessionNumber();
         gameData.gameNumber = saveData.GetNextGameNumber();
@@ -371,7 +379,9 @@ public class LaunchControl : MonoBehaviour
 
     private void incrementCountDownCode()
     {
-        Sprite newCountDownSprite = countDownSprites[Random.Range(0, countDownSprites.Count)];
+        Sprite newCountDownSprite = countDownSprites[
+            UnityEngine.Random.Range(0, countDownSprites.Count)
+        ];
         // remove the number from the list to avoid selected a repeat number next time.
         countDownSprites.Remove(newCountDownSprite);
         if (countDownSprite != null)

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -512,6 +512,20 @@ public class LaunchControl : MonoBehaviour
             gameData.headSpeedDegPerSecSD = MathsUtilities.RoundTo2DecimalPlaces(standardDeviation);
         }
 
+        int nSamplesAbove40DegPerSec = 0;
+        foreach (float headSpeed in headSpeedSamples)
+        {
+            if (headSpeed > 40)
+            {
+                nSamplesAbove40DegPerSec++;
+            }
+        }
+        float percentTimeAbove40DegPerSec =
+            (nSamplesAbove40DegPerSec / headSpeedSamples.Count()) * 100;
+        gameData.percentTimeAbove40DegPerSec = MathsUtilities.RoundTo2DecimalPlaces(
+            percentTimeAbove40DegPerSec
+        );
+
         SaveGameData<RocketLaunchData> saveData = new(saveFilename);
         gameData.sessionNumber = CaptureSessionData.CurrentSessionNumber();
         gameData.gameNumber = saveData.GetNextGameNumber();

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -233,7 +233,7 @@ public class LaunchControl : MonoBehaviour
         else
         {
             GazeItem gazeItem = AddToBuffers();
-            CheckIfPlayerIsOutOfRange();
+            SetPlayerIsOutOfRangeFlag();
             SampleForSaveData();
 
             headSpeed = CalculateHeadSpeed(speedTime, true);
@@ -277,7 +277,7 @@ public class LaunchControl : MonoBehaviour
         get => targetObject;
     }
 
-    private void CheckIfPlayerIsOutOfRange()
+    private void SetPlayerIsOutOfRangeFlag()
     {
         if (!tracker.isPlayerDetected())
         {

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -267,8 +267,9 @@ public class LaunchControl : MonoBehaviour
             headPose.Rotation.RollDegrees = 0f;
             headPose.TimeStampMicroSeconds = (long)(Time.timeSinceLevelLoad * 1000000);
 
-            gazeItem.gazePoint.X = mousePos.x;
-            gazeItem.gazePoint.Y = mousePos.y;
+            Vector3 mousePoseWorld = Camera.main.ScreenToWorldPoint(mousePos);
+            gazeItem.gazePoint.X = mousePoseWorld.x;
+            gazeItem.gazePoint.Y = mousePoseWorld.y;
             gazeItem.gazePoint.TimeStampMicroSeconds = (long)(Time.timeSinceLevelLoad * 1000000);
         }
         else

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using TMPro;
 using Tobii.GameIntegration.Net;
-using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
 /// <summary>
@@ -82,6 +82,9 @@ public class LaunchControl : MonoBehaviour
     [Header("Save data Variables")]
     [SerializeField, Tooltip("The interval between samples for the save data.")]
     private float samplingIntervalSeconds = 0.5f;
+
+    [SerializeField, Tooltip("Whether to write sampled speeds to a file called rocket-speeds.txt")]
+    private bool writeSampledSpeeds = false;
 
     [Header("User Interface Items")]
     [SerializeField, Tooltip("Sprites to display on the countdown.")]
@@ -576,12 +579,12 @@ public class LaunchControl : MonoBehaviour
             }
 
             float percentTimeAbove40DegPerSec =
-                (nSamplesAbove40DegPerSec / headSpeedSamples.Count()) * 100;
+                ((float)nSamplesAbove40DegPerSec / headSpeedSamples.Count()) * 100;
             gameData.percentTimeAbove40DegPerSec = MathsUtilities.RoundTo2DecimalPlaces(
                 percentTimeAbove40DegPerSec
             );
             float percentTimeGazeOnTarget =
-                (nSamplesGazeSteady / (nSamplesGazeSteady + nSamplesGazeNotSteady)) * 100;
+                ((float)nSamplesGazeSteady / (nSamplesGazeSteady + nSamplesGazeNotSteady)) * 100;
             gameData.percentTimeGazeOnTarget = MathsUtilities.RoundTo2DecimalPlaces(
                 percentTimeGazeOnTarget
             );
@@ -604,6 +607,13 @@ public class LaunchControl : MonoBehaviour
         gameData.sessionNumber = CaptureSessionData.CurrentSessionNumber();
         gameData.gameNumber = saveData.GetNextGameNumber();
         saveData.Save(gameData);
+
+        if (writeSampledSpeeds)
+        {
+            string filePath = Path.Combine(Application.persistentDataPath, "rocket-speeds.txt");
+            IEnumerable<string> lines = headSpeedSamples.Select(v => v.ToString());
+            File.WriteAllLines(filePath, lines);
+        }
 
         // Update save data for this session
         if (gameComplete)

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -147,7 +147,7 @@ public class LaunchControl : MonoBehaviour
             ? "Nod your head and repeat the code to launch the rocket!"
             : "Shake your head and repeat the code to launch the rocket!";
         gameData = new RocketLaunchData();
-        timeToLaunch = (float)launchTime * adaptiveDifficulty;
+        timeToLaunch = launchTime;
         gazeBuffer = new GazeBuffer(gazeBufferCapacity, minDataRequired);
         incrementCountDownCode();
     }

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using TMPro;
 using Tobii.GameIntegration.Net;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
 /// <summary>
@@ -32,9 +33,6 @@ public class LaunchControl : MonoBehaviour
     ]
     private float minimumSpeedYaw = 40;
 
-    [SerializeField, Tooltip("The interval between head speed samples for the save data.")]
-    private float samplingIntervalSeconds = 0.5f;
-
     [
         SerializeField,
         Tooltip("The minimum number of head pose readings used to calculate a head speed")
@@ -60,7 +58,7 @@ public class LaunchControl : MonoBehaviour
     private float gazeTolerance = 3.0f;
 
     [SerializeField, Tooltip("The minimum number of gaze points used to calculate steadiness")]
-    private int minNItemsForGaze = 2;
+    private int minNItemsForGaze = 5;
 
     [SerializeField, Tooltip("The game object the user is supposed to look at.")]
     private GameObject targetObject;
@@ -80,6 +78,10 @@ public class LaunchControl : MonoBehaviour
         Range(1, 10)
     ]
     private float adaptiveDifficulty;
+
+    [Header("Save data Variables")]
+    [SerializeField, Tooltip("The interval between samples for the save data.")]
+    private float samplingIntervalSeconds = 0.5f;
 
     [Header("User Interface Items")]
     [SerializeField, Tooltip("Sprites to display on the countdown.")]
@@ -119,15 +121,21 @@ public class LaunchControl : MonoBehaviour
     private RocketLaunchData gameData;
     private float rocketSpeed;
     private float mouseToGazeScale = 10f; // if we're debugging using the mouse the reported speeds are much higher than with gaze.
-    bool outOfRange = false; // whether the player is out of range of the tracker
-    float secondsSinceLastOutOfRange = 0; // number of seconds elapsed since the player was last out of range
-    private List<float> headSpeedSamples = new List<float>(); // Samples for save data
-    private float timeToNextSample;
 
-    // gaze steadiness paraemeters
+    // gaze steadiness parameters
     private float timeToSpriteChange;
     private Sprite countDownSprite = null;
     private GazeBuffer gazeBuffer;
+
+    // Sampling for save data parameters
+    private List<float> headSpeedSamples = new List<float>();
+    private int nSamplesGazeSteady = 0;
+    private int nSamplesGazeNotSteady = 0;
+    private float timeToNextSample;
+
+    // track when the player is in or out of range of the tracker
+    bool outOfRange = false;
+    float secondsSinceLastOutOfRange = 0;
 
     private string saveFilename = "RocketLaunchScores";
     private bool gameActive = true;
@@ -157,12 +165,10 @@ public class LaunchControl : MonoBehaviour
         if (lastGameData.Count() == 0 || lastGameData.Last().headMovementPlane == "yaw")
         {
             usePitch = true;
-            minimumSpeed = minimumSpeedPitch;
         }
         else
         {
             usePitch = false;
-            minimumSpeed = minimumSpeedYaw;
         }
         minimumSpeed = usePitch ? minimumSpeedPitch : minimumSpeedYaw;
 
@@ -225,24 +231,10 @@ public class LaunchControl : MonoBehaviour
         {
             GazeItem gazeItem = AddToBuffers();
             CheckIfPlayerIsOutOfRange();
-
-            // Take sample of head speed for save data
-            if (timeToNextSample <= 0)
-            {
-                float speedSample = CalculateHeadSpeed(samplingIntervalSeconds, false);
-                if (speedSample > 0)
-                {
-                    headSpeedSamples.Add(speedSample);
-                }
-                timeToNextSample = samplingIntervalSeconds;
-            }
-            else
-            {
-                timeToNextSample -= Time.deltaTime;
-            }
+            SampleForSaveData();
 
             headSpeed = CalculateHeadSpeed(speedTime, true);
-            bool gazeIsSteady = CalculateGazeSteady();
+            bool gazeIsSteady = CalculateGazeSteady(gazeTime);
 
             writeDebugInformation(headSpeed, gazeItem, gazeIsSteady);
 
@@ -300,6 +292,36 @@ public class LaunchControl : MonoBehaviour
         }
     }
 
+    private void SampleForSaveData()
+    {
+        if (timeToNextSample > 0)
+        {
+            timeToNextSample -= Time.deltaTime;
+            return;
+        }
+
+        if (!outOfRange && secondsSinceLastOutOfRange >= samplingIntervalSeconds)
+        {
+            float speedSample = CalculateHeadSpeed(samplingIntervalSeconds, false);
+            if (speedSample > 0)
+            {
+                headSpeedSamples.Add(speedSample);
+            }
+
+            bool gazeSample = CalculateGazeSteady(samplingIntervalSeconds);
+            if (gazeSample)
+            {
+                nSamplesGazeSteady++;
+            }
+            else
+            {
+                nSamplesGazeNotSteady++;
+            }
+        }
+
+        timeToNextSample = samplingIntervalSeconds;
+    }
+
     /// <summary>
     /// Calculate the current head speed
     /// </summary>
@@ -335,10 +357,10 @@ public class LaunchControl : MonoBehaviour
         return Mathf.Max(0, currentSpeed); // Clamp to zero to avoid negative speeds
     }
 
-    private bool CalculateGazeSteady()
+    private bool CalculateGazeSteady(float timeSeconds)
     {
         bool gazeIsSteady = false;
-        if (outOfRange || secondsSinceLastOutOfRange < gazeTime)
+        if (outOfRange || secondsSinceLastOutOfRange < timeSeconds)
         {
             return gazeIsSteady;
         }
@@ -347,7 +369,7 @@ public class LaunchControl : MonoBehaviour
         {
             Vector2 targetCentre = GetTargetCentre();
             gazeIsSteady = gazeBuffer.gazeSteady(
-                gazeTime,
+                timeSeconds,
                 gazeTolerance,
                 targetCentre.x,
                 targetCentre.y
@@ -355,7 +377,7 @@ public class LaunchControl : MonoBehaviour
         }
         else
         {
-            gazeIsSteady = gazeBuffer.gazeSteady(gazeTime, gazeTolerance);
+            gazeIsSteady = gazeBuffer.gazeSteady(timeSeconds, gazeTolerance);
         }
 
         return gazeIsSteady;
@@ -551,6 +573,11 @@ public class LaunchControl : MonoBehaviour
                 (nSamplesAbove40DegPerSec / headSpeedSamples.Count()) * 100;
             gameData.percentTimeAbove40DegPerSec = MathsUtilities.RoundTo2DecimalPlaces(
                 percentTimeAbove40DegPerSec
+            );
+            float percentTimeGazeOnTarget =
+                (nSamplesGazeSteady / (nSamplesGazeSteady + nSamplesGazeNotSteady)) * 100;
+            gameData.percentTimeGazeOnTarget = MathsUtilities.RoundTo2DecimalPlaces(
+                percentTimeGazeOnTarget
             );
 
             gameData.timeInAdaptationWindow1 = MathsUtilities.RoundTo2DecimalPlaces(

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -32,6 +32,15 @@ public class LaunchControl : MonoBehaviour
     ]
     private float minimumSpeedYaw = 40;
 
+    [SerializeField, Tooltip("The interval between head speed samples for the save data.")]
+    private float samplingIntervalSeconds = 0.5f;
+
+    [
+        SerializeField,
+        Tooltip("The minimum number of head pose readings used to calculate a head speed")
+    ]
+    private int minNItemsForSpeed = 5;
+
     [Header("Steady Gaze Variables")]
     [SerializeField, Tooltip("Time between new random numbers in seconds.")]
     private float timerDuration = 1.0F;
@@ -49,6 +58,9 @@ public class LaunchControl : MonoBehaviour
         )
     ]
     private float gazeTolerance = 3.0f;
+
+    [SerializeField, Tooltip("The minimum number of gaze points used to calculate steadiness")]
+    private int minNItemsForGaze = 2;
 
     [SerializeField, Tooltip("The game object the user is supposed to look at.")]
     private GameObject targetObject;
@@ -106,10 +118,11 @@ public class LaunchControl : MonoBehaviour
     private float headSpeed; // current head speed
     private RocketLaunchData gameData;
     private float rocketSpeed;
-    private int minDataRequired = 2; // we need at least 2 data points to calculate a speed or steadiness
     private float mouseToGazeScale = 10f; // if we're debugging using the mouse the reported speeds are much higher than with gaze.
     bool outOfRange = false; // whether the player is out of range of the tracker
     float secondsSinceLastOutOfRange = 0; // number of seconds elapsed since the player was last out of range
+    private List<float> headSpeedSamples = new List<float>(); // Samples for save data
+    private float timeToNextSample;
 
     // gaze steadiness paraemeters
     private float timeToSpriteChange;
@@ -155,12 +168,13 @@ public class LaunchControl : MonoBehaviour
 
         InitialiseTarget();
 
-        headPoseBuffer = new HeadPoseBuffer(headPoseBufferCapacity, minDataRequired);
+        headPoseBuffer = new HeadPoseBuffer(headPoseBufferCapacity, minNItemsForSpeed);
         instructionsText.text = usePitch
             ? "Nod your head and repeat the code to launch the rocket!"
             : "Shake your head and repeat the code to launch the rocket!";
         timeToLaunch = launchTime;
-        gazeBuffer = new GazeBuffer(gazeBufferCapacity, minDataRequired);
+        timeToNextSample = samplingIntervalSeconds;
+        gazeBuffer = new GazeBuffer(gazeBufferCapacity, minNItemsForGaze);
     }
 
     // Start is called once before the first execution of Update after the MonoBehaviour is created
@@ -210,9 +224,24 @@ public class LaunchControl : MonoBehaviour
         else
         {
             GazeItem gazeItem = AddToBuffers();
-
             CheckIfPlayerIsOutOfRange();
-            CalculateHeadSpeed();
+
+            // Take sample of head speed for save data
+            if (timeToNextSample <= 0)
+            {
+                float speedSample = CalculateHeadSpeed(samplingIntervalSeconds, false);
+                if (speedSample > 0)
+                {
+                    headSpeedSamples.Add(speedSample);
+                }
+                timeToNextSample = samplingIntervalSeconds;
+            }
+            else
+            {
+                timeToNextSample -= Time.deltaTime;
+            }
+
+            headSpeed = CalculateHeadSpeed(speedTime, true);
             bool gazeIsSteady = CalculateGazeSteady();
 
             writeDebugInformation(headSpeed, gazeItem, gazeIsSteady);
@@ -271,27 +300,39 @@ public class LaunchControl : MonoBehaviour
         }
     }
 
-    private void CalculateHeadSpeed()
+    /// <summary>
+    /// Calculate the current head speed
+    /// </summary>
+    /// <param name="timeSeconds">The number of seconds of data to use</param>
+    /// <param name="compensateOtherAxis">If True, the speed of movement in the perpendicular axis will be subtracted.
+    /// (e.g. if this game is using Pitch, then the returned speed will be headPitchSpeed - headYawSpeed)</param>
+    private float CalculateHeadSpeed(float timeSeconds, bool compensateOtherAxis)
     {
-        if (outOfRange || secondsSinceLastOutOfRange < speedTime)
+        if (outOfRange || secondsSinceLastOutOfRange < timeSeconds)
         {
-            headSpeed = 0;
-            return;
+            return 0;
         }
 
+        HeadPoseAxis axis;
+        HeadPoseAxis perpendicularAxis;
         if (usePitch)
         {
-            headSpeed =
-                headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Pitch)
-                - headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Yaw);
+            axis = HeadPoseAxis.Pitch;
+            perpendicularAxis = HeadPoseAxis.Yaw;
         }
         else
         {
-            headSpeed =
-                headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Yaw)
-                - headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Pitch);
+            axis = HeadPoseAxis.Yaw;
+            perpendicularAxis = HeadPoseAxis.Pitch;
         }
-        headSpeed = Mathf.Max(0, headSpeed); // Clamp to zero to avoid negative speeds
+
+        float currentSpeed = headPoseBuffer.getSpeed(timeSeconds, axis);
+        if (compensateOtherAxis)
+        {
+            currentSpeed -= headPoseBuffer.getSpeed(timeSeconds, perpendicularAxis);
+        }
+
+        return Mathf.Max(0, currentSpeed); // Clamp to zero to avoid negative speeds
     }
 
     private bool CalculateGazeSteady()
@@ -449,6 +490,27 @@ public class LaunchControl : MonoBehaviour
         gameData.gameDurationSeconds = MathsUtilities.RoundToNearestInt(
             (float)gameDuration.TotalSeconds
         );
+
+        if (headSpeedSamples.Count() == 0)
+        {
+            gameData.headSpeedDegPerSecPeak = 0;
+            gameData.headSpeedDegPerSecMean = 0;
+            gameData.headSpeedDegPerSecMedian = 0;
+            gameData.headSpeedDegPerSecSD = 0;
+        }
+        else
+        {
+            gameData.headSpeedDegPerSecPeak = MathsUtilities.RoundTo2DecimalPlaces(
+                headSpeedSamples.Max()
+            );
+            gameData.headSpeedDegPerSecMean = MathsUtilities.RoundTo2DecimalPlaces(
+                headSpeedSamples.Average()
+            );
+            float median = MathsUtilities.Median(headSpeedSamples);
+            gameData.headSpeedDegPerSecMedian = MathsUtilities.RoundTo2DecimalPlaces(median);
+            float standardDeviation = MathsUtilities.StandardDeviation(headSpeedSamples);
+            gameData.headSpeedDegPerSecSD = MathsUtilities.RoundTo2DecimalPlaces(standardDeviation);
+        }
 
         SaveGameData<RocketLaunchData> saveData = new(saveFilename);
         gameData.sessionNumber = CaptureSessionData.CurrentSessionNumber();

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -108,6 +108,8 @@ public class LaunchControl : MonoBehaviour
     private float rocketSpeed;
     private int minDataRequired = 2; // we need at least 2 data points to calculate a speed or steadiness
     private float mouseToGazeScale = 10f; // if we're debugging using the mouse the reported speeds are much higher than with gaze.
+    bool outOfRange = false; // whether the player is out of range of the tracker
+    float secondsSinceLastOutOfRange = 0; // number of seconds elapsed since the player was last out of range
 
     // gaze steadiness paraemeters
     private float timeToSpriteChange;
@@ -208,39 +210,12 @@ public class LaunchControl : MonoBehaviour
         else
         {
             GazeItem gazeItem = AddToBuffers();
-            bool gazeIsSteady = false;
 
-            if (usePitch)
-            {
-                headSpeed =
-                    headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Pitch)
-                    - headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Yaw);
-            }
-            else
-            {
-                headSpeed =
-                    headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Yaw)
-                    - headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Pitch);
-            }
-            headSpeed = Mathf.Max(0, headSpeed); // Clamp to zero to avoid negative speeds
+            CheckIfPlayerIsOutOfRange();
+            CalculateHeadSpeed();
+            bool gazeIsSteady = CalculateGazeSteady();
 
-            // gaze steadiness
-            float targetX = 0f;
-            float targetY = 0f;
-            if (targetObject != null)
-            {
-                // use centre of bounds in case the target object is not centred
-                targetX = targetObject.transform.GetComponent<Renderer>().bounds.center.x;
-                targetY = targetObject.transform.GetComponent<Renderer>().bounds.center.y;
-
-                gazeIsSteady = gazeBuffer.gazeSteady(gazeTime, gazeTolerance, targetX, targetY);
-            }
-            else
-            {
-                gazeIsSteady = gazeBuffer.gazeSteady(gazeTime, gazeTolerance);
-            }
-
-            writeDebugInformation(headSpeed, gazeItem, targetX, targetY, gazeIsSteady);
+            writeDebugInformation(headSpeed, gazeItem, gazeIsSteady);
 
             if (timeToSpriteChange > 0)
             {
@@ -276,6 +251,88 @@ public class LaunchControl : MonoBehaviour
     public GameObject TargetObject
     {
         get => targetObject;
+    }
+
+    private void CheckIfPlayerIsOutOfRange()
+    {
+        if (!tracker.isPlayerDetected())
+        {
+            outOfRange = true;
+            secondsSinceLastOutOfRange = 0;
+        }
+        else
+        {
+            // If they are already detected as in-range, increase the timer
+            if (!outOfRange)
+            {
+                secondsSinceLastOutOfRange += Time.deltaTime;
+            }
+            outOfRange = false;
+        }
+    }
+
+    private void CalculateHeadSpeed()
+    {
+        if (outOfRange || secondsSinceLastOutOfRange < speedTime)
+        {
+            headSpeed = 0;
+            return;
+        }
+
+        if (usePitch)
+        {
+            headSpeed =
+                headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Pitch)
+                - headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Yaw);
+        }
+        else
+        {
+            headSpeed =
+                headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Yaw)
+                - headPoseBuffer.getSpeed(speedTime, HeadPoseAxis.Pitch);
+        }
+        headSpeed = Mathf.Max(0, headSpeed); // Clamp to zero to avoid negative speeds
+    }
+
+    private bool CalculateGazeSteady()
+    {
+        bool gazeIsSteady = false;
+        if (outOfRange || secondsSinceLastOutOfRange < gazeTime)
+        {
+            return gazeIsSteady;
+        }
+
+        if (targetObject != null)
+        {
+            Vector2 targetCentre = GetTargetCentre();
+            gazeIsSteady = gazeBuffer.gazeSteady(
+                gazeTime,
+                gazeTolerance,
+                targetCentre.x,
+                targetCentre.y
+            );
+        }
+        else
+        {
+            gazeIsSteady = gazeBuffer.gazeSteady(gazeTime, gazeTolerance);
+        }
+
+        return gazeIsSteady;
+    }
+
+    private Vector2 GetTargetCentre()
+    {
+        float targetX = 0f;
+        float targetY = 0f;
+
+        if (targetObject is not null)
+        {
+            // use centre of bounds in case the target object is not centred
+            targetX = targetObject.transform.GetComponent<Renderer>().bounds.center.x;
+            targetY = targetObject.transform.GetComponent<Renderer>().bounds.center.y;
+        }
+
+        return new Vector2(targetX, targetY);
     }
 
     /// <summary>
@@ -317,13 +374,7 @@ public class LaunchControl : MonoBehaviour
         return gazeItem;
     }
 
-    private void writeDebugInformation(
-        float headSpeed,
-        GazeItem gazeItem,
-        float targetX,
-        float targetY,
-        bool gazeIsSteady
-    )
+    private void writeDebugInformation(float headSpeed, GazeItem gazeItem, bool gazeIsSteady)
     {
         if (speedStatusText != null)
         {
@@ -333,11 +384,13 @@ public class LaunchControl : MonoBehaviour
         if (gazeStatusText != null)
         {
             string steadyText = gazeIsSteady ? "Gaze is steady" : "Gaze is not steady";
+            Vector2 targetCentre = GetTargetCentre();
+
             gazeStatusText.text =
                 "Look here -> "
-                + targetX
+                + targetCentre.x
                 + ", "
-                + targetY
+                + targetCentre.y
                 + "\n"
                 + "Looking here -> "
                 + gazeItem.gazePoint.X

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -108,6 +108,7 @@ public class LaunchControl : MonoBehaviour
     private GazeBuffer gazeBuffer;
 
     private string saveFilename = "RocketLaunchScores";
+    private bool gameActive = true;
 
     private TextMeshProUGUI winText;
 
@@ -316,16 +317,30 @@ public class LaunchControl : MonoBehaviour
 
     private void EndGame()
     {
-        winText.text = "Blast Off! Well Done.";
-        winScreen.SetActive(true);
-        SaveGameData();
-        this.enabled = false;
+        if (gameActive)
+        {
+            gameActive = false;
+            winText.text = "Blast Off! Well Done.";
+            winScreen.SetActive(true);
+            SaveGameData(true);
+            this.enabled = false;
+        }
     }
 
-    private void SaveGameData()
+    private void OnDestroy()
+    {
+        // If the scene is exited early (e.g. with the exit button), then save this
+        // partial game's data
+        if (gameActive)
+        {
+            SaveGameData(false);
+        }
+    }
+
+    private void SaveGameData(bool gameComplete)
     {
         // Update save data for this game
-        gameData.gameCompleted = true;
+        gameData.gameCompleted = gameComplete;
         gameData.pitch = usePitch;
         gameData.launchTimeSeconds = launchTime;
         gameData.LogEndTime();
@@ -334,7 +349,10 @@ public class LaunchControl : MonoBehaviour
         saveData.Save(gameData);
 
         // Update save data for this session
-        CaptureSessionData.MarkGameAsComplete("nCompleteRocketLaunchGames");
+        if (gameComplete)
+        {
+            CaptureSessionData.MarkGameAsComplete("nCompleteRocketLaunchGames");
+        }
     }
 
     private void incrementCountDownCode()

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/LaunchControl.cs
@@ -279,7 +279,7 @@ public class LaunchControl : MonoBehaviour
 
     private void SetPlayerIsOutOfRangeFlag()
     {
-        if (!tracker.isPlayerDetected())
+        if (!useMouseForTracker && !tracker.isPlayerDetected())
         {
             outOfRange = true;
             secondsSinceLastOutOfRange = 0;

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/RocketLaunchData.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/RocketLaunchData.cs
@@ -13,4 +13,10 @@ public class RocketLaunchData : GameData
     public float headSpeedDegPerSecPeak;
     public float headSpeedDegPerSecMedian;
     public float headSpeedDegPerSecSD;
+    public float percentTimeAbove40DegPerSec;
+    public float percentTimeGazeOnTarget;
+    public float timeInAdaptationWindow1;
+    public float timeInAdaptationWindow2;
+    public float timeInAdaptationWindow3;
+    public float timeInAdaptationWindow4;
 }

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/RocketLaunchData.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/RocketLaunchData.cs
@@ -9,4 +9,8 @@ public class RocketLaunchData : GameData
     public float launchTimeSeconds;
     public float minimumHeadSpeed;
     public float gazeTolerance;
+    public float headSpeedDegPerSecMean;
+    public float headSpeedDegPerSecPeak;
+    public float headSpeedDegPerSecMedian;
+    public float headSpeedDegPerSecSD;
 }

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/RocketLaunchData.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/RocketLaunchData.cs
@@ -4,6 +4,7 @@
 [System.Serializable]
 public class RocketLaunchData : GameData
 {
-    public bool pitch; // true if head pitch was used, false if yaw was used
+    public string headMovementPlane;
+    public int gameDurationSeconds;
     public float launchTimeSeconds;
 }

--- a/projects/AstroBalance/Assets/Scripts/RocketLaunch/RocketLaunchData.cs
+++ b/projects/AstroBalance/Assets/Scripts/RocketLaunch/RocketLaunchData.cs
@@ -7,4 +7,6 @@ public class RocketLaunchData : GameData
     public string headMovementPlane;
     public int gameDurationSeconds;
     public float launchTimeSeconds;
+    public float minimumHeadSpeed;
+    public float gazeTolerance;
 }


### PR DESCRIPTION
For https://github.com/UCL/AstroBalance/issues/20

Expands rocket launch data, see extra clarifications from David at: https://github.com/UCL/AstroBalance/issues/20#issuecomment-4478025967 (also older comments at: https://github.com/UCL/AstroBalance/issues/20#issuecomment-4237421181 - most have been superseded, except that requiring 'Only measuring measuring their head speed with gaze on target')

Some extra notes:
- Similar to the implementation for star collector, samples are taken for the save data every `samplingIntervalSeconds`. I've kept this parameter separate from the `speedTime` / `gazeTime` used for the main gameplay, so these can be adjusted separately.
- As with other games, I've excluded any time periods including out of range time from the data. I've also incorporated this into the main gameplay that checks for speed / gaze steadiness - previously, it was possible to keep your gaze on the target and move your head to start the progress bar filling, then quickly walk out of range - as the buffer remained full of old data the progress bar could continue filling without the player being present. Now out of range time resets velocities to 0 and gaze steadiness to False.
- I added a 'write sampled speeds' checkbox for easier debugging of saved speeds - should also be useful for https://github.com/UCL/AstroBalance/issues/77
- I've left the 'adaptive level' column out for now, and added a note to the description of: https://github.com/UCL/AstroBalance/issues/81 . This will be simpler to add once the adaptive difficulty for rocket launch has been finalised.